### PR TITLE
fix castOrFail(any:) does not match any overloads

### DIFF
--- a/Sources/Object.swift
+++ b/Sources/Object.swift
@@ -15,7 +15,7 @@ enum ObjectType: String {
 
 public class Object: Decodable {
     public static func decode(_ e: Extractor) throws -> Self {
-        guard let object = try ObjectType(rawValue: e <| "object") else { return try castOrFail(any: e) }
+        guard let object = try ObjectType(rawValue: e <| "object") else { return try castOrFail(e) }
         switch object {
         case .token:
             return try castOrFail(Token(e))


### PR DESCRIPTION
Since `any` is internal variable name as follws, so is not needed to call the function (and this causes compile error)

<img width="249" alt="2017-09-14 12 06 47" src="https://user-images.githubusercontent.com/10028587/30410316-3f1ad5ae-9945-11e7-923a-300b9f0b9b46.png">

https://github.com/ikesyo/Himotoki/blob/e39f8025c0b28c55eb66109753603c46e2275681/Sources/Casting.swift#L13

```swift
public func castOrFail<T>(_ any: Any) throws -> T {
}
```