### PR TITLE
Fix the error code of Apple Pay related error.

### DIFF
--- a/PAYJP.podspec
+++ b/PAYJP.podspec
@@ -19,10 +19,10 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.xcconfig = {
-    'SWIFT_VERSION' => '4.1'
+    'SWIFT_VERSION' => '4.2'
   }
 
-  s.source_files = ['Sources/**/*',
+  s.source_files = ['Sources/**/*.{h,m,swift}',
                     'Carthage/Checkouts/Himotoki/Sources/**/*.swift',
                     'Carthage/Checkouts/Result/Result/**/*.swift']
   s.public_header_files = 'Sources/**/*.h'

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pod 'PAYJP'
 
 ## SDK開発環境
 
-- Swift 4.1
+- Swift 4.2
 - Result: https://github.com/antitypical/Result/
 - Himotoki: https://github.com/ikesyo/Himotoki/
 

--- a/Sources/APIError.swift
+++ b/Sources/APIError.swift
@@ -52,7 +52,7 @@ public enum APIError: LocalizedError {
         case .invalidApplePayToken(let token):
             userInfo[PAYErrorInvalidApplePayTokenObject] = token
             return APINSError(domain: PAYErrorDomain,
-                              code: PAYErrorServiceError,
+                              code: PAYErrorInvalidApplePayToken,
                               userInfo: userInfo)
         case .systemError(let error):
             userInfo[PAYErrorSystemErrorObject] = error

--- a/Sources/Card.swift
+++ b/Sources/Card.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by k@binc.jp on 10/3/16.
-//  Copyright © 2016 BASE, Inc. All rights reserved.
+//  Copyright © 2016 PAY, Inc. All rights reserved.
 //
 //  https://pay.jp/docs/api/#token-トークン
 //

--- a/Sources/Object.swift
+++ b/Sources/Object.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by k@binc.jp on 10/4/16.
-//  Copyright © 2016 BASE, Inc. All rights reserved.
+//  Copyright © 2016 PAY, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Sources/Token.swift
+++ b/Sources/Token.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by k@binc.jp on 9/29/16.
-//  Copyright © 2016 BASE, Inc. All rights reserved.
+//  Copyright © 2016 PAY, Inc. All rights reserved.
 //
 //  https://pay.jp/docs/api/#token-トークン
 //

--- a/Sources/Transformers.swift
+++ b/Sources/Transformers.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by k@binc.jp on 10/3/16.
-//  Copyright © 2016 BASE, Inc. All rights reserved.
+//  Copyright © 2016 PAY, Inc. All rights reserved.
 //  
 //  Himotoki Custom Transformer
 //  https://github.com/ikesyo/Himotoki#value-transformation

--- a/Tests/APIErrorNSErrorTests.swift
+++ b/Tests/APIErrorNSErrorTests.swift
@@ -20,6 +20,8 @@ class APIErrorNSErrorTests: XCTestCase {
         
         XCTAssertNotNil(errorToken)
         XCTAssertEqual(errorToken, token)
+        
+        XCTAssertEqual(nserror?.code, PAYErrorInvalidApplePayToken)
         XCTAssertEqual(nserror?.localizedDescription, "Invalid Apple Pay Token")
     }
     
@@ -33,6 +35,8 @@ class APIErrorNSErrorTests: XCTestCase {
         
         XCTAssertNotNil(systemError)
         XCTAssertEqual(systemError, error)
+        
+        XCTAssertEqual(nserror?.code, PAYErrorSystemError)
         XCTAssertEqual(nserror?.localizedDescription, "mock error")
     }
     
@@ -46,6 +50,8 @@ class APIErrorNSErrorTests: XCTestCase {
         
         XCTAssertNotNil(errorResponse)
         XCTAssertEqual(errorResponse, response)
+        
+        XCTAssertEqual(nserror?.code, PAYErrorInvalidResponse)
         XCTAssertEqual(nserror?.localizedDescription, "The response is not a HTTPURLResponse instance.")
     }
     
@@ -59,6 +65,8 @@ class APIErrorNSErrorTests: XCTestCase {
         
         XCTAssertNotNil(errorData)
         XCTAssertEqual(errorData, data)
+        
+        XCTAssertEqual(nserror?.code, PAYErrorInvalidResponseBody)
         XCTAssertEqual(nserror?.localizedDescription, "The response body\'s data is not a valid JSON object.")
     }
     
@@ -73,6 +81,8 @@ class APIErrorNSErrorTests: XCTestCase {
         
         XCTAssertNotNil(payError)
         XCTAssertEqual(payError, errorObject)
+        
+        XCTAssertEqual(nserror?.code, PAYErrorServiceError)
         XCTAssertEqual(nserror?.localizedDescription, "Invalid card number")
     }
     
@@ -86,6 +96,8 @@ class APIErrorNSErrorTests: XCTestCase {
         
         XCTAssertNotNil(someObject)
         XCTAssertEqual(someObject, errorObject)
+        
+        XCTAssertEqual(nserror?.code, PAYErrorInvalidJSON)
         XCTAssertEqual(nserror?.localizedDescription, "Unable parse JSON object into expected classes.")
     }
 }

--- a/Tests/APIErrorNSErrorTests.swift
+++ b/Tests/APIErrorNSErrorTests.swift
@@ -3,7 +3,7 @@
 //  PAYJPTests
 //
 //  Created by Li-Hsuan Chen on 2018/05/23.
-//  Copyright © 2018年 BASE, Inc. All rights reserved.
+//  Copyright © 2018年 PAY, Inc. All rights reserved.
 //
 
 import XCTest

--- a/Tests/CardFromTokenTests.swift
+++ b/Tests/CardFromTokenTests.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by k@binc.jp on 2017/01/05.
-//  Copyright © 2017 BASE, Inc. All rights reserved.
+//  Copyright © 2017 PAY, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Tests/PAYErrorResponseTests.swift
+++ b/Tests/PAYErrorResponseTests.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by Li-Hsuan Chen on 2018/05/21.
-//  Copyright © 2018年 BASE, Inc. All rights reserved.
+//  Copyright © 2018年 PAY, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Tests/TestFixture.swift
+++ b/Tests/TestFixture.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by k@binc.jp on 2017/01/05.
-//  Copyright © 2017 BASE, Inc. All rights reserved.
+//  Copyright © 2017 PAY, Inc. All rights reserved.
 //
 
 import Foundation

--- a/Tests/TokenTests.swift
+++ b/Tests/TokenTests.swift
@@ -3,7 +3,7 @@
 //  PAYJP
 //
 //  Created by k@binc.jp on 10/3/16.
-//  Copyright © 2016 BASE, Inc. All rights reserved.
+//  Copyright © 2016 PAY, Inc. All rights reserved.
 //
 
 import Foundation

--- a/example-objc/example-objc.xcodeproj/project.pbxproj
+++ b/example-objc/example-objc.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-objc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -379,6 +380,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-objc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/example-objc/example-objc.xcodeproj/project.pbxproj
+++ b/example-objc/example-objc.xcodeproj/project.pbxproj
@@ -125,7 +125,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0920;
-				ORGANIZATIONNAME = "Tatsuya Kitagawa";
+				ORGANIZATIONNAME = "PAY, Inc.";
 				TargetAttributes = {
 					32CB11631FDA97A1007AD8F5 = {
 						CreatedOnToolsVersion = 9.2;

--- a/example-objc/example-objc/AppDelegate.h
+++ b/example-objc/example-objc/AppDelegate.h
@@ -3,7 +3,7 @@
 //  example-objc
 //
 //  Created by Tatsuya Kitagawa on 2017/12/08.
-//  Copyright © 2017年 Tatsuya Kitagawa. All rights reserved.
+//  Copyright © 2017年 PAY, Inc. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/example-objc/example-objc/AppDelegate.m
+++ b/example-objc/example-objc/AppDelegate.m
@@ -3,7 +3,7 @@
 //  example-objc
 //
 //  Created by Tatsuya Kitagawa on 2017/12/08.
-//  Copyright © 2017年 Tatsuya Kitagawa. All rights reserved.
+//  Copyright © 2017年 PAY, Inc. All rights reserved.
 //
 
 #import "AppDelegate.h"

--- a/example-objc/example-objc/ViewController.h
+++ b/example-objc/example-objc/ViewController.h
@@ -3,7 +3,7 @@
 //  example-objc
 //
 //  Created by Tatsuya Kitagawa on 2017/12/08.
-//  Copyright © 2017年 Tatsuya Kitagawa. All rights reserved.
+//  Copyright © 2017年 PAY, Inc. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/example-objc/example-objc/ViewController.m
+++ b/example-objc/example-objc/ViewController.m
@@ -3,7 +3,7 @@
 //  example-objc
 //
 //  Created by Tatsuya Kitagawa on 2017/12/08.
-//  Copyright © 2017年 Tatsuya Kitagawa. All rights reserved.
+//  Copyright © 2017年 PAY, Inc. All rights reserved.
 //
 
 #import "ViewController.h"

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -335,7 +335,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/example-swift/example-swift/AppDelegate.swift
+++ b/example-swift/example-swift/AppDelegate.swift
@@ -3,6 +3,7 @@
 //  example-swift
 //
 //  Created by Tatsuya Kitagawa on 2017/12/08.
+//  Copyright © 2017年 PAY, Inc. All rights reserved.
 //
 
 import UIKit

--- a/example-swift/example-swift/AppDelegate.swift
+++ b/example-swift/example-swift/AppDelegate.swift
@@ -12,9 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         return true
     }
 

--- a/example-swift/example-swift/ViewController.swift
+++ b/example-swift/example-swift/ViewController.swift
@@ -3,7 +3,7 @@
 //  Example
 //
 //  Created by Tatsuya Kitagawa on 2017/12/07.
-//  Copyright © 2017年 BASE, Inc. All rights reserved.
+//  Copyright © 2017年 PAY, Inc. All rights reserved.
 //
 
 import UIKit


### PR DESCRIPTION
## Overview

It seems there is a missed use of error code at Apple Pay's error object, it should be `PAYErrorInvalidApplePayToken` rather than `PAYErrorServiceError`.

## Check Items

- [x] The code is correct.
- [x] The tests are passed.
- [ ] Example Project in Swift is executable
- [ ] Example Project in Objective-C is executable