### PR TITLE
Add SwiftUI Sample

### DIFF
--- a/example-swift/example-swift-ui/AppDelegate.swift
+++ b/example-swift/example-swift-ui/AppDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  AppDelegate.swift
+//  example-swift-ui
+//
+//  Created by Tatsuya Kitagawa on 2020/07/21.
+//
+
+import UIKit
+import PAYJP
+
+let PAYJPPublicKey = "pk_test_0383a1b8f91e8a6e3ea0e2a9"
+let App3DSRedirectURL = "exampleswift://tds/complete"
+let App3DSRedirectURLKey = "swift-app"
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        PAYJPSDK.publicKey = PAYJPPublicKey
+        PAYJPSDK.locale = Locale.current
+        PAYJPSDK.threeDSecureURLConfiguration =
+            ThreeDSecureURLConfiguration(redirectURL: URL(string: App3DSRedirectURL)!,
+                                         redirectURLKey: App3DSRedirectURLKey)
+        return true
+    }
+
+    func application(_ app: UIApplication,
+                     open url: URL,
+                     options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+
+        return ThreeDSecureProcessHandler.shared.completeThreeDSecureProcess(url: url)
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}

--- a/example-swift/example-swift-ui/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/example-swift/example-swift-ui/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example-swift/example-swift-ui/Assets.xcassets/Contents.json
+++ b/example-swift/example-swift-ui/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example-swift/example-swift-ui/Base.lproj/LaunchScreen.storyboard
+++ b/example-swift/example-swift-ui/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/example-swift/example-swift-ui/ContentView.swift
+++ b/example-swift/example-swift-ui/ContentView.swift
@@ -1,0 +1,74 @@
+//
+//  ContentView.swift
+//  example-swift-ui
+//
+//  Created by Tatsuya Kitagawa on 2020/07/21.
+//
+
+import SwiftUI
+import PAYJP
+
+struct ContentView: View {
+    @ObservedObject private var cardFormDelegate = CardFormDelegate()
+    var body: some View {
+        Button("Add Credit Card") {
+            self.cardFormDelegate.isPresented.toggle()
+        }
+        .sheet(isPresented: self.$cardFormDelegate.isPresented) {
+            CardFormViewControllerWrapper(delegate: self.cardFormDelegate)
+        }
+    }
+}
+
+// MARK: - CardFormViewControllerDelegate
+
+class CardFormDelegate: ObservableObject, CardFormViewControllerDelegate {
+    @Published var isPresented: Bool = false
+
+    func cardFormViewController(_: CardFormViewController, didCompleteWith result: CardFormResult) {
+        switch result {
+        case .cancel:
+            print("CardFormResult.cancel")
+        case .success:
+            print("CardFormResult.success")
+            DispatchQueue.main.async { [weak self] in
+                self?.isPresented.toggle()
+            }
+        }
+    }
+
+    func cardFormViewController(_: CardFormViewController,
+                                didProduced token: Token,
+                                completionHandler: @escaping (Error?) -> Void) {
+        print("token = \(token.rawValue)")
+        // TODO: send token to server
+        completionHandler(nil)
+    }
+}
+
+// MARK: - CardFormViewControllerWrapper
+
+struct CardFormViewControllerWrapper: UIViewControllerRepresentable {
+    let delegate: CardFormViewControllerDelegate
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let cardFormVc =  CardFormViewController.createCardFormViewController(delegate: delegate,
+        viewType: .displayStyled)
+        let naviVc = UINavigationController(rootViewController: cardFormVc)
+        naviVc.presentationController?.delegate = cardFormVc
+        return naviVc
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+    }
+
+    typealias UIViewControllerType = UINavigationController
+}
+
+// MARK: - Preview
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/example-swift/example-swift-ui/Info.plist
+++ b/example-swift/example-swift-ui/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/example-swift/example-swift-ui/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/example-swift/example-swift-ui/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example-swift/example-swift-ui/SceneDelegate.swift
+++ b/example-swift/example-swift-ui/SceneDelegate.swift
@@ -1,0 +1,63 @@
+//
+//  SceneDelegate.swift
+//  example-swift-ui
+//
+//  Created by Tatsuya Kitagawa on 2020/07/21.
+//
+
+import UIKit
+import SwiftUI
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+
+        // Create the SwiftUI view that provides the window contents.
+        let contentView = ContentView()
+
+        // Use a UIHostingController as window root view controller.
+        if let windowScene = scene as? UIWindowScene {
+            let window = UIWindow(windowScene: windowScene)
+            window.rootViewController = UIHostingController(rootView: contentView)
+            self.window = window
+            window.makeKeyAndVisible()
+        }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		32B471E024C6AD180061579C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471DF24C6AD180061579C /* AppDelegate.swift */; };
+		32B471E224C6AD180061579C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471E124C6AD180061579C /* SceneDelegate.swift */; };
+		32B471E424C6AD180061579C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471E324C6AD180061579C /* ContentView.swift */; };
+		32B471E624C6AD1B0061579C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 32B471E524C6AD1B0061579C /* Assets.xcassets */; };
+		32B471E924C6AD1B0061579C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 32B471E824C6AD1B0061579C /* Preview Assets.xcassets */; };
+		32B471EC24C6AD1B0061579C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 32B471EA24C6AD1B0061579C /* LaunchScreen.storyboard */; };
+		32B471F124C6AE910061579C /* PAYJP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32CB113A1FDA8507007AD8F5 /* PAYJP.framework */; };
 		32CB11281FDA7E3D007AD8F5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CB11271FDA7E3D007AD8F5 /* AppDelegate.swift */; };
 		32CB112A1FDA7E3D007AD8F5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CB11291FDA7E3D007AD8F5 /* ViewController.swift */; };
 		32CB112D1FDA7E3D007AD8F5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 32CB112B1FDA7E3D007AD8F5 /* Main.storyboard */; };
@@ -22,6 +29,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		32B471DD24C6AD180061579C /* example-swift-ui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-swift-ui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		32B471DF24C6AD180061579C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		32B471E124C6AD180061579C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		32B471E324C6AD180061579C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		32B471E524C6AD1B0061579C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		32B471E824C6AD1B0061579C /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		32B471EB24C6AD1B0061579C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		32B471ED24C6AD1B0061579C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		32CB11241FDA7E3D007AD8F5 /* example-swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		32CB11271FDA7E3D007AD8F5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		32CB11291FDA7E3D007AD8F5 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -40,6 +55,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		32B471DA24C6AD180061579C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32B471F124C6AE910061579C /* PAYJP.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		32CB11211FDA7E3D007AD8F5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -51,9 +74,32 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		32B471DE24C6AD180061579C /* example-swift-ui */ = {
+			isa = PBXGroup;
+			children = (
+				32B471DF24C6AD180061579C /* AppDelegate.swift */,
+				32B471E124C6AD180061579C /* SceneDelegate.swift */,
+				32B471E324C6AD180061579C /* ContentView.swift */,
+				32B471E524C6AD1B0061579C /* Assets.xcassets */,
+				32B471EA24C6AD1B0061579C /* LaunchScreen.storyboard */,
+				32B471ED24C6AD1B0061579C /* Info.plist */,
+				32B471E724C6AD1B0061579C /* Preview Content */,
+			);
+			path = "example-swift-ui";
+			sourceTree = "<group>";
+		};
+		32B471E724C6AD1B0061579C /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				32B471E824C6AD1B0061579C /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		32CB111B1FDA7E3D007AD8F5 = {
 			isa = PBXGroup;
 			children = (
+				32B471DE24C6AD180061579C /* example-swift-ui */,
 				32CB11391FDA8507007AD8F5 /* Frameworks */,
 				32CB11251FDA7E3D007AD8F5 /* Products */,
 				32CB11261FDA7E3D007AD8F5 /* example-swift */,
@@ -64,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				32CB11241FDA7E3D007AD8F5 /* example-swift.app */,
+				32B471DD24C6AD180061579C /* example-swift-ui.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -98,6 +145,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		32B471DC24C6AD180061579C /* example-swift-ui */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 32B471EE24C6AD1B0061579C /* Build configuration list for PBXNativeTarget "example-swift-ui" */;
+			buildPhases = (
+				32B471D924C6AD180061579C /* Sources */,
+				32B471DA24C6AD180061579C /* Frameworks */,
+				32B471DB24C6AD180061579C /* Resources */,
+				32B471F224C6AED10061579C /* ShellScript */,
+				32B471F324C6AF080061579C /* Run SwiftLint */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "example-swift-ui";
+			productName = "example-swift-ui";
+			productReference = 32B471DD24C6AD180061579C /* example-swift-ui.app */;
+			productType = "com.apple.product-type.application";
+		};
 		32CB11231FDA7E3D007AD8F5 /* example-swift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 32CB11361FDA7E3D007AD8F5 /* Build configuration list for PBXNativeTarget "example-swift" */;
@@ -123,9 +189,13 @@
 		32CB111C1FDA7E3D007AD8F5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0920;
+				LastSwiftUpdateCheck = 1160;
 				LastUpgradeCheck = 0940;
 				TargetAttributes = {
+					32B471DC24C6AD180061579C = {
+						CreatedOnToolsVersion = 11.6;
+						ProvisioningStyle = Automatic;
+					};
 					32CB11231FDA7E3D007AD8F5 = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1020;
@@ -148,11 +218,22 @@
 			projectRoot = "";
 			targets = (
 				32CB11231FDA7E3D007AD8F5 /* example-swift */,
+				32B471DC24C6AD180061579C /* example-swift-ui */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		32B471DB24C6AD180061579C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32B471EC24C6AD1B0061579C /* LaunchScreen.storyboard in Resources */,
+				32B471E924C6AD1B0061579C /* Preview Assets.xcassets in Resources */,
+				32B471E624C6AD1B0061579C /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		32CB11221FDA7E3D007AD8F5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -185,6 +266,42 @@
 			shellPath = /bin/sh;
 			shellScript = "sh ./run-swiftlint.sh\n";
 		};
+		32B471F224C6AED10061579C /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/PAYJP.framework",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+		32B471F324C6AF080061579C /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh ./run-swiftlint.sh\n";
+		};
 		32CB113C1FDA8517007AD8F5 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -198,11 +315,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		32B471D924C6AD180061579C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32B471E024C6AD180061579C /* AppDelegate.swift in Sources */,
+				32B471E224C6AD180061579C /* SceneDelegate.swift in Sources */,
+				32B471E424C6AD180061579C /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		32CB11201FDA7E3D007AD8F5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -220,6 +347,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
+		32B471EA24C6AD1B0061579C /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				32B471EB24C6AD1B0061579C /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
 		32CB112B1FDA7E3D007AD8F5 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -250,6 +385,55 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		32B471EF24C6AD1B0061579C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"example-swift-ui/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "example-swift-ui/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-ui";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		32B471F024C6AD1B0061579C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"example-swift-ui/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = "example-swift-ui/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-ui";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		32CB11341FDA7E3D007AD8F5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -408,6 +592,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		32B471EE24C6AD1B0061579C /* Build configuration list for PBXNativeTarget "example-swift-ui" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				32B471EF24C6AD1B0061579C /* Debug */,
+				32B471F024C6AD1B0061579C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		32CB111F1FDA7E3D007AD8F5 /* Build configuration list for PBXProject "example-swift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
payjp-ios の `CardFormViewController` を SwiftUI から利用する場合、`UIViewControllerRepresentable` に適合したクラス・構造体を用意する必要があります。

参考: [iOSでの利用 | PAY.JP](https://pay.jp/docs/mobileapp-ios#use-card-form-controller)

example-swift プロジェクトに `example-swift-ui` ターゲットを新たに追加し、カードフォームを表示する最小限のサンプルコードを実装しました。

<img src="https://user-images.githubusercontent.com/949882/88025523-5c62ab00-cb6f-11ea-91b5-397e8ba5f285.gif" width=300 />