### PR TITLE
fix: 'creditCardNumber' is only available in iOS 10.0 or newer

### DIFF
--- a/Sources/Views/CardFormDisplayStyledView.swift
+++ b/Sources/Views/CardFormDisplayStyledView.swift
@@ -266,7 +266,9 @@ public class CardFormDisplayStyledView: CardFormView, CardFormProperties {
         cvcTextField.clearButtonMode = .whileEditing
         cardHolderTextField.clearButtonMode = .whileEditing
 
-        cardNumberTextField.textContentType = .creditCardNumber
+        if #available(iOS 10.0, *) {
+            cardNumberTextField.textContentType = .creditCardNumber
+        }
         cardNumberTextField.keyboardType = .numberPad
         expirationTextField.keyboardType = .numberPad
         cvcTextField.keyboardType = .numberPad


### PR DESCRIPTION
### issue

https://github.com/payjp/payjp-ios/issues/50