### PR TITLE
カードフォーム画面で403エラーの判別ができない

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install HomeBrew
         run: |
-          brew bundle
-          cat Brewfile.lock.json
+          brew bundle || true
+          cat Brewfile.lock.json || true
       - name: Select Xcode
         run: sudo xcode-select -s '/Applications/Xcode_12.2.app/Contents/Developer'
       - run: xcodebuild -version

--- a/Sources/Views/ErrorTranslator.swift
+++ b/Sources/Views/ErrorTranslator.swift
@@ -20,13 +20,14 @@ struct ErrorTranslator: ErrorTranslatorType {
         if let apiError = error as? APIError {
             switch apiError {
             case .serviceError(let response):
+                let codeDescription = " (code:\(response.code ?? "none"))"
                 switch response.status {
                 case 402:
-                    return response.message ?? "payjp_card_form_screen_error_unknown".localized
+                    return response.message ?? "payjp_card_form_screen_error_unknown".localized + codeDescription
                 case 500..<600:
-                    return "payjp_card_form_screen_error_server".localized
+                    return "payjp_card_form_screen_error_server".localized + codeDescription
                 default:
-                    return "payjp_card_form_screen_error_application".localized
+                    return "payjp_card_form_screen_error_application".localized + codeDescription
                 }
             case .rateLimitExceeded:
                 return "payjp_card_form_screen_error_rate_limit_exceeded".localized

--- a/Tests/Views/ErrorTranslatorTests.swift
+++ b/Tests/Views/ErrorTranslatorTests.swift
@@ -49,20 +49,44 @@ class ErrorTranslatorTests: XCTestCase {
         XCTAssertEqual(result, "402 error")
     }
 
-    func testTranslate_error401() {
-        let payError = MockPAYErrorResponse(status: 401, message: "401 error")
+    func testTranslate_error402_nomessage() {
+        let payError = MockPAYErrorResponse(status: 402, message: nil, code: "something_wrong")
         let apiError = APIError.serviceError(payError)
 
         let result = translator.translate(error: apiError)
-        XCTAssertEqual(result, "payjp_card_form_screen_error_application".localized)
+        XCTAssertEqual(result, "payjp_card_form_screen_error_unknown".localized + " (code:something_wrong)")
+    }
+
+    func testTranslate_error403() {
+        let payError = MockPAYErrorResponse(status: 403, message: "403 error", code: "something_wrong")
+        let apiError = APIError.serviceError(payError)
+
+        let result = translator.translate(error: apiError)
+        XCTAssertEqual(result, "payjp_card_form_screen_error_application".localized + " (code:something_wrong)")
+    }
+
+    func testTranslate_error401() {
+        let payError = MockPAYErrorResponse(status: 401, message: "401 error", code: "something_wrong")
+        let apiError = APIError.serviceError(payError)
+
+        let result = translator.translate(error: apiError)
+        XCTAssertEqual(result, "payjp_card_form_screen_error_application".localized + " (code:something_wrong)")
+    }
+
+    func testTranslate_error400() {
+        let payError = MockPAYErrorResponse(status: 400, message: "400 error")
+        let apiError = APIError.serviceError(payError)
+
+        let result = translator.translate(error: apiError)
+        XCTAssertEqual(result, "payjp_card_form_screen_error_application".localized + " (code:none)")
     }
 
     func testTranslate_error500() {
-        let payError = MockPAYErrorResponse(status: 500, message: "500 error")
+        let payError = MockPAYErrorResponse(status: 500, message: "500 error", code: "maintenance")
         let apiError = APIError.serviceError(payError)
 
         let result = translator.translate(error: apiError)
-        XCTAssertEqual(result, "payjp_card_form_screen_error_server".localized)
+        XCTAssertEqual(result, "payjp_card_form_screen_error_server".localized + " (code:maintenance)")
     }
 
     func testTranslate_rateLimitExceeded() {


### PR DESCRIPTION
- 403のときに固定のエラーメッセージを表示されるのでどのエラーなのかわからない
- 例えば card_flagged と言ったエラーコードは画面から読み取れるようにエラーメッセージの末尾にコードを追加