### PR TITLE
3DセキュアのためのAPIが一部公開されていなかったのを追加

### DIFF
--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -92,6 +92,17 @@ import PassKit
     ) {
         accountsService.getAcceptedBrands(tenantId: tenantId, completion: completion)
     }
+
+    /// Finish 3D Secure flow on tokenization
+    /// - parameter tokenId:    identifier of the Token
+    /// - parameter completion: completion action
+    @nonobjc
+    public func finishTokenThreeDSecure(
+        with tokenId: String,
+        completion: @escaping (Result<Token, APIError>) -> Void
+    ) {
+        tokensService.finishTokenThreeDSecure(tokenId: tokenId, completion: completion)
+    }
 }
 
 /// Objective-C API
@@ -160,6 +171,21 @@ extension APIClient {
             case .success(let result):
                 let converted = result.map { (brand: CardBrand) -> NSString in return brand.rawValue as NSString }
                 completionHandler(converted, nil)
+            case .failure(let error):
+                completionHandler(nil, self.nsErrorConverter.convert(from: error))
+            }
+        }
+    }
+
+    @objc public func finishTokenThreeDSecureWith(
+        _ tokenId: String,
+        completionHandler: @escaping (Token?, NSError?) -> Void
+    ) {
+        finishTokenThreeDSecure(with: tokenId) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let result):
+                completionHandler(result, nil)
             case .failure(let error):
                 completionHandler(nil, self.nsErrorConverter.convert(from: error))
             }

--- a/Tests/APIClientTests.swift
+++ b/Tests/APIClientTests.swift
@@ -274,6 +274,64 @@ class APIClientTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    func testFinishTokenThreeDSecure() {
+        let apiClient = APIClient.shared
+        let tokenId = "tok_eff34b780cbebd61e87f09ecc9c6"
+        let json = TestFixture.JSON(by: "token.json")
+        let decoder = JSONDecoder.shared
+        let expectedToken = try! Token.decodeJson(with: json, using: decoder)
+
+        let expectation = self.expectation(description: self.description)
+
+        apiClient.finishTokenThreeDSecure(with: tokenId) { result in
+            switch result {
+            case .success(let token):
+                XCTAssertEqual(token.identifer, expectedToken.identifer)
+                XCTAssertEqual(token.used, expectedToken.used)
+                XCTAssertEqual(token.livemode, expectedToken.livemode)
+                XCTAssertEqual(token.createdAt, expectedToken.createdAt)
+                XCTAssertEqual(token.rawValue?.count, expectedToken.rawValue?.count)
+                XCTAssertEqual(token.card.identifer, expectedToken.card.identifer)
+                XCTAssertEqual(token.card.rawValue?.count, expectedToken.card.rawValue?.count)
+                expectation.fulfill()
+            default:
+                XCTFail()
+            }
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFinishTokenThreeDSecure_objc() {
+        let apiClient = APIClient.shared
+        let tokenId = "tok_eff34b780cbebd61e87f09ecc9c6"
+        let json = TestFixture.JSON(by: "token.json")
+        let decoder = JSONDecoder.shared
+        let expectedToken = try! Token.decodeJson(with: json, using: decoder)
+
+        let expectation = self.expectation(description: self.description)
+
+        apiClient.finishTokenThreeDSecureWith(tokenId) { (token, error) in
+            XCTAssertNil(error)
+            guard let token = token else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(token.identifer, expectedToken.identifer)
+            XCTAssertEqual(token.used, expectedToken.used)
+            XCTAssertEqual(token.livemode, expectedToken.livemode)
+            XCTAssertEqual(token.createdAt, expectedToken.createdAt)
+            XCTAssertEqual(token.rawValue?.count, expectedToken.rawValue?.count)
+            XCTAssertEqual(token.card.identifer, expectedToken.card.identifer)
+            XCTAssertEqual(token.card.rawValue?.count, expectedToken.card.rawValue?.count)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    // MARK: - Helper
+
     private func stubCardInputResponse(cardNumber: String,
                                        cardCvc: String,
                                        cardExpMonth: String,

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3219F14C26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3219F14B26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift */; };
 		32B471E024C6AD180061579C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471DF24C6AD180061579C /* AppDelegate.swift */; };
 		32B471E224C6AD180061579C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471E124C6AD180061579C /* SceneDelegate.swift */; };
 		32B471E424C6AD180061579C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471E324C6AD180061579C /* ContentView.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3219F14B26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormViewWith3DSViewController.swift; sourceTree = "<group>"; };
 		32B471DD24C6AD180061579C /* example-swift-ui.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-swift-ui.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		32B471DF24C6AD180061579C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		32B471E124C6AD180061579C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				32CB112E1FDA7E3D007AD8F5 /* Assets.xcassets */,
 				ED50839223278BB800C64A7F /* CardFormViewExampleViewController.swift */,
 				ED5085BC232A0FE300C64A7F /* CardFormViewScrollViewController.swift */,
+				3219F14B26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift */,
 				ED630C1623556BF4006C061E /* ColorTheme.swift */,
 				32CB11331FDA7E3D007AD8F5 /* Info.plist */,
 				32CB11301FDA7E3D007AD8F5 /* LaunchScreen.storyboard */,
@@ -334,6 +337,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3219F14C26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift in Sources */,
 				ED8BDA062383BA3B00680C05 /* ExampleHostViewController.swift in Sources */,
 				ED5085BD232A0FE300C64A7F /* CardFormViewScrollViewController.swift in Sources */,
 				ED630C1723556BF4006C061E /* ColorTheme.swift in Sources */,

--- a/example-swift/example-swift/Base.lproj/Main.storyboard
+++ b/example-swift/example-swift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SOm-Ex-W3S">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SOm-Ex-W3S">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -15,7 +15,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="IgJ-bL-PYI">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection id="ErQ-9s-VQN">
                                 <cells>
@@ -110,8 +110,28 @@
                                             <segue destination="5zR-1c-XlU" kind="show" id="1hi-74-GgM"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="slR-R0-W8h" style="IBUITableViewCellStyleDefault" id="kGC-Pb-Wfc">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="qwQ-4M-drp" style="IBUITableViewCellStyleDefault" id="Akl-Ia-7TA">
                                         <rect key="frame" x="0.0" y="238" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Akl-Ia-7TA" id="CO4-v4-oU9">
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Card Form View with 3D Secure" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qwQ-4M-drp">
+                                                    <rect key="frame" x="16" y="0.0" width="324" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="71f-1K-WQt" kind="show" id="7f9-UD-sCV"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="slR-R0-W8h" style="IBUITableViewCellStyleDefault" id="kGC-Pb-Wfc">
+                                        <rect key="frame" x="0.0" y="282" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kGC-Pb-Wfc" id="2G1-Vp-axv">
                                             <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
@@ -151,7 +171,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ByJ-Ji-wtV">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Card Information" id="LvM-LH-3jc">
                                 <cells>
@@ -315,9 +335,6 @@
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XcR-UC-zeG">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="351"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isHolderRequired" value="YES"/>
-                                                </userDefinedRuntimeAttributes>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HbA-gz-Twn">
                                                 <rect key="frame" x="0.0" y="359" width="375" height="267.5"/>
@@ -339,14 +356,14 @@
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
-                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uh2-Rm-h2d">
+                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uh2-Rm-h2d">
                                                         <rect key="frame" x="16" y="47" width="343" height="30"/>
                                                         <state key="normal" title="Create Token"/>
                                                         <connections>
                                                             <action selector="createToken:" destination="5zR-1c-XlU" eventType="touchUpInside" id="fVi-OU-Rpz"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uhK-Rl-R8Y">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uhK-Rl-R8Y">
                                                         <rect key="frame" x="16" y="85" width="343" height="30"/>
                                                         <state key="normal" title="Validate Form And Create Token"/>
                                                         <connections>
@@ -382,7 +399,7 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="tvR-ZZ-Qlw" firstAttribute="top" secondItem="Iq5-CG-r17" secondAttribute="top" id="418-44-tPp"/>
                                     <constraint firstItem="tvR-ZZ-Qlw" firstAttribute="leading" secondItem="Iq5-CG-r17" secondAttribute="leading" id="9QP-R4-RQ3"/>
@@ -392,6 +409,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="bd8-hY-Yo6"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="Iq5-CG-r17" firstAttribute="top" secondItem="sFh-l4-2td" secondAttribute="top" id="9ap-QV-iMv"/>
@@ -399,7 +417,6 @@
                             <constraint firstItem="Iq5-CG-r17" firstAttribute="leading" secondItem="sFh-l4-2td" secondAttribute="leading" id="Cor-9r-8Ac"/>
                             <constraint firstItem="Iq5-CG-r17" firstAttribute="bottom" secondItem="sFh-l4-2td" secondAttribute="bottom" id="xjp-Ze-Ucb"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="bd8-hY-Yo6"/>
                     </view>
                     <connections>
                         <outlet property="createTokenButton" destination="Uh2-Rm-h2d" id="MdB-Gc-jcF"/>
@@ -411,7 +428,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JGZ-rB-MKX" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-380" y="1209.4452773613195"/>
+            <point key="canvasLocation" x="-278" y="1209"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="RMR-ub-41I">
@@ -436,7 +453,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="1hC-Zo-UoR">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Card Information" id="U5z-sT-dp5">
                                 <cells>
@@ -673,5 +690,90 @@
             </objects>
             <point key="canvasLocation" x="1335" y="1209"/>
         </scene>
+        <!--Card Form View with 3DS-->
+        <scene sceneID="mP2-Ih-6sN">
+            <objects>
+                <viewController title="Card Form View with 3DS" id="71f-1K-WQt" customClass="CardFormViewWith3DSViewController" customModule="example_swift" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="SyX-mv-eAI">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="428-zV-vWT">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tx2-Bg-y48">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="507.5"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Yh-4C-rLP">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="351"/>
+                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hLI-eO-ImE">
+                                                <rect key="frame" x="0.0" y="359" width="375" height="148.5"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rsW-km-b6w">
+                                                        <rect key="frame" x="16" y="8" width="343" height="30"/>
+                                                        <state key="normal" title="Create Token"/>
+                                                        <connections>
+                                                            <action selector="createToken:" destination="71f-1K-WQt" eventType="touchUpInside" id="eeO-uO-Cjy"/>
+                                                        </connections>
+                                                    </button>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="aPm-XZ-kv3">
+                                                        <rect key="frame" x="16" y="46" width="343" height="94.5"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="token id" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MJ4-w3-oBP">
+                                                                <rect key="frame" x="0.0" y="8" width="343" height="20.5"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ywk-eJ-LPB">
+                                                                <rect key="frame" x="0.0" y="36.5" width="343" height="50"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <edgeInsets key="layoutMargins" top="8" left="0.0" bottom="8" right="0.0"/>
+                                                    </stackView>
+                                                </subviews>
+                                                <edgeInsets key="layoutMargins" top="8" left="16" bottom="8" right="16"/>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="tx2-Bg-y48" secondAttribute="bottom" id="7Jb-0W-s00"/>
+                                    <constraint firstItem="tx2-Bg-y48" firstAttribute="width" secondItem="428-zV-vWT" secondAttribute="width" id="HGC-2m-JeO"/>
+                                    <constraint firstAttribute="trailing" secondItem="tx2-Bg-y48" secondAttribute="trailing" id="McA-2j-7dv"/>
+                                    <constraint firstItem="tx2-Bg-y48" firstAttribute="leading" secondItem="428-zV-vWT" secondAttribute="leading" id="Tsd-8I-wrg"/>
+                                    <constraint firstItem="tx2-Bg-y48" firstAttribute="top" secondItem="428-zV-vWT" secondAttribute="top" id="mox-LA-8yM"/>
+                                </constraints>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vfW-ed-8nf"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="428-zV-vWT" firstAttribute="leading" secondItem="SyX-mv-eAI" secondAttribute="leading" id="3Jy-Vl-FUX"/>
+                            <constraint firstItem="428-zV-vWT" firstAttribute="bottom" secondItem="SyX-mv-eAI" secondAttribute="bottom" id="4tQ-WP-6BW"/>
+                            <constraint firstAttribute="trailing" secondItem="428-zV-vWT" secondAttribute="trailing" id="YTV-D3-Urh"/>
+                            <constraint firstItem="428-zV-vWT" firstAttribute="top" secondItem="SyX-mv-eAI" secondAttribute="top" id="YcV-BV-KoD"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="createTokenButton" destination="rsW-km-b6w" id="8aN-B9-Ybi"/>
+                        <outlet property="formContentView" destination="6Yh-4C-rLP" id="8KT-0F-1BU"/>
+                        <outlet property="tokenIdLabel" destination="Ywk-eJ-LPB" id="bxI-jk-QLe"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mug-KC-m1p" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-279" y="1911"/>
+        </scene>
     </scenes>
+    <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/example-swift/example-swift/CardFormViewWith3DSViewController.swift
+++ b/example-swift/example-swift/CardFormViewWith3DSViewController.swift
@@ -1,0 +1,146 @@
+//
+//  CardFormViewWith3DSViewController.swift
+//  example-swift
+//
+//  Created by Tatsuya Kitagawa on 2021/07/28.
+//
+
+import UIKit
+import PAYJP
+
+class CardFormViewWith3DSViewController: UIViewController {
+
+    @IBOutlet private weak var formContentView: UIView!
+    @IBOutlet private weak var createTokenButton: UIButton!
+    @IBOutlet private weak var tokenIdLabel: UILabel!
+
+    private var cardFormView: CardFormLabelStyledView!
+    private var tokenOperationStatus: TokenOperationStatus = .acceptable
+    private var pendingToken: Token?
+
+    override func viewDidLoad() {
+        let x: CGFloat = self.formContentView.bounds.origin.x
+        let y: CGFloat = self.formContentView.bounds.origin.y
+
+        let width: CGFloat = self.formContentView.bounds.width
+        let height: CGFloat = self.formContentView.bounds.height
+
+        let frame: CGRect = CGRect(x: x, y: y, width: width, height: height)
+        cardFormView = CardFormLabelStyledView(frame: frame)
+        cardFormView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        cardFormView.setCardHolderRequired(true)
+        cardFormView.delegate = self
+
+        self.formContentView.addSubview(cardFormView)
+
+        NotificationCenter.default.addObserver(self,
+                                            selector: #selector(handleTokenOperationStatusChange(notification:)),
+                                            name: .payjpTokenOperationStatusChanged,
+                                            object: nil)
+        
+    }
+
+    @objc private func handleTokenOperationStatusChange(notification: Notification) {
+        if let value = notification.userInfo?[PAYNotificationKey.newTokenOperationStatus] as? Int,
+        let newStatus = TokenOperationStatus.init(rawValue: value) {
+            self.tokenOperationStatus = newStatus
+            self.updateButtonEnabled()
+        }
+    }
+
+    private func updateButtonEnabled() {
+        let isAcceptable = self.tokenOperationStatus == .acceptable
+        self.createTokenButton.isEnabled = isAcceptable && self.cardFormView.isValid
+    }
+
+    @IBAction func createToken(_ sender: Any) {
+        if !self.cardFormView.isValid {
+            return
+        }
+        createToken()
+    }
+
+    func createToken() {
+        self.cardFormView.createToken { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let token):
+                DispatchQueue.main.async {
+                    if let tdsStatus = token.card.threeDSecureStatus, tdsStatus == .unverified {
+                            self.pendingToken = token
+                            ThreeDSecureProcessHandler.shared.startThreeDSecureProcess(viewController: self, delegate: self, token: token)
+                        return
+                    }
+                    self.tokenIdLabel.text = token.identifer
+                    self.showToken(token: token)
+                }
+            case .failure(let error):
+                if let apiError = error as? APIError, let payError =
+                    apiError.payError {
+                    print("[errorResponse] \(payError.description)")
+                }
+
+                DispatchQueue.main.async {
+                    self.tokenIdLabel.text = nil
+                    self.showError(error: error)
+                }
+            }
+        }
+    }
+
+    func completeTokenTds() {
+        guard let pendingToken = pendingToken else {
+            return
+        }
+        APIClient.shared.finishTokenThreeDSecure(with: pendingToken.identifer) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let token):
+                self.pendingToken = nil
+                DispatchQueue.main.async {
+                    self.tokenIdLabel.text = token.identifer
+                    self.showToken(token: token)
+                }
+            case .failure(let error):
+                if let payError = error.payError {
+                    print("[errorResponse] \(payError.description)")
+                }
+
+                DispatchQueue.main.async {
+                    self.tokenIdLabel.text = nil
+                    self.showError(error: error)
+                }
+            }
+        }
+    }
+ }
+
+// MARK: - CardFormViewDelegate
+
+extension CardFormViewWith3DSViewController: CardFormViewDelegate {
+    func formInputValidated(in cardFormView: UIView, isValid: Bool) {
+        self.updateButtonEnabled()
+    }
+
+    func formInputDoneTapped(in cardFormView: UIView) {
+        self.createToken()
+    }
+}
+
+// MARK: - ThreeDSecureProcessHandlerDelegate
+
+extension CardFormViewWith3DSViewController: ThreeDSecureProcessHandlerDelegate {
+    func threeDSecureProcessHandlerDidFinish(_ handler: ThreeDSecureProcessHandler, status: ThreeDSecureProcessStatus) {
+        switch status {
+        case .completed:
+            // 3DSの処理を完了する
+            completeTokenTds()
+        case .canceled:
+            // UI更新など
+            break
+        default:
+            break
+        }
+    }
+}
+


### PR DESCRIPTION
カードホルダーによる3Dセキュアの認証が終わった後に、 `Token.card.threeDSecureStatus` が `.verified` なTokenを再取得するためのPublicなAPIが欠如していたため追加します。

```swift
func APIClient.finishTokenThreeDSecure(tokenId: String, completion: (Result<Token, APIError>) -> Void)
```

モバイルSDKの3Dセキュア導入については現在非公開のドキュメントがあり、公開準備中です。

- [x] publicなfunctionを追加
- [x] テストの追加
- [x] サンプルコードを追加