### PR TITLE
トークン作成リクエスト時に3Dセキュア実施可否を設定する

### DIFF
--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -53,6 +53,7 @@ import PassKit
     /// - parameter name:               Credit card holder name `TARO YAMADA`
     /// - parameter email:              Credit card email (Extra Attributes) e.g. `test@example.com`
     /// - parameter phone:              Credit card phone number (Extra Attributes) E.164  e.g. `+819012345678`
+    /// - parameter useThreeDSecure:    Whether use 3-D secure or not
     /// - parameter completion:         completion action
     @nonobjc
     public func createToken(
@@ -64,6 +65,7 @@ import PassKit
         tenantId: String? = nil,
         email: String? = nil,
         phone: String? = nil,
+        useThreeDSecure: Bool,
         completion: @escaping (Result<Token, APIError>) -> Void
     ) {
         tokensService.createToken(cardNumber: cardNumber,
@@ -74,6 +76,7 @@ import PassKit
                                   tenantId: tenantId,
                                   email: email,
                                   phone: phone,
+                                  threeDSecure: useThreeDSecure,
                                   completion: completion)
     }
 
@@ -135,6 +138,9 @@ extension APIClient {
         expirationYear: String,
         name: String?,
         tenantId: String?,
+        email: String?,
+        phone: String?,
+        useThreeDSecure: Bool,
         completionHandler: @escaping (Token?, NSError?) -> Void
     ) {
         createToken(with: cardNumber,
@@ -142,7 +148,10 @@ extension APIClient {
                     expirationMonth: expirationMonth,
                     expirationYear: expirationYear,
                     name: name,
-                    tenantId: tenantId
+                    tenantId: tenantId,
+                    email: email,
+                    phone: phone,
+                    useThreeDSecure: useThreeDSecure
         ) { [weak self] result in
             guard let self = self else { return }
             switch result {

--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -65,7 +65,7 @@ import PassKit
         tenantId: String? = nil,
         email: String? = nil,
         phone: String? = nil,
-        useThreeDSecure: Bool,
+        useThreeDSecure: Bool = false,
         completion: @escaping (Result<Token, APIError>) -> Void
     ) {
         tokensService.createToken(cardNumber: cardNumber,

--- a/Sources/Networking/Requests/CreateTokenRequest.swift
+++ b/Sources/Networking/Requests/CreateTokenRequest.swift
@@ -25,6 +25,7 @@ struct CreateTokenRequest: BaseRequest {
         parameters["tenant"] = tenantId
         parameters["card[email]"] = email
         parameters["card[phone]"] = phone
+        parameters["three_d_secure"] = String(threeDSecure)
         return parameters
     }
 
@@ -38,4 +39,5 @@ struct CreateTokenRequest: BaseRequest {
     let tenantId: String?
     let email: String?
     let phone: String?
+    let threeDSecure: Bool
 }

--- a/Sources/Networking/Services/TokensService.swift
+++ b/Sources/Networking/Services/TokensService.swift
@@ -22,6 +22,7 @@ protocol TokenServiceType {
         tenantId: String?,
         email: String?,
         phone: String?,
+        threeDSecure: Bool,
         completion: @escaping (Result<Token, APIError>) -> Void
     ) -> URLSessionDataTask?
 
@@ -72,6 +73,7 @@ class TokenService: TokenServiceType {
         tenantId: String?,
         email: String?,
         phone: String?,
+        threeDSecure: Bool,
         completion: @escaping (Result<Token, APIError>) -> Void
     ) -> URLSessionDataTask? {
         let request = CreateTokenRequest(
@@ -82,7 +84,9 @@ class TokenService: TokenServiceType {
             name: name,
             tenantId: tenantId,
             email: email,
-            phone: phone)
+            phone: phone,
+            threeDSecure: threeDSecure
+        )
         self.checkTokenOperationStatus()
         self.tokenOperationObserverInternal.startRequest()
         return self.client.request(with: request) { [weak self] result in

--- a/Sources/Networking/TokenOperationObserver.swift
+++ b/Sources/Networking/TokenOperationObserver.swift
@@ -43,7 +43,7 @@ class TokenOperationObserver: TokenOperationObserverInternalType {
 
     // MARK: - TokenOperationObserverType
 
-    private (set) var status: TokenOperationStatus = .acceptable {
+    private(set) var status: TokenOperationStatus = .acceptable {
         didSet {
             if status != oldValue {
                 DispatchQueue.main.async { [weak self] in

--- a/Sources/ThreeDSecure/ThreeDSecureSFSafariViewControllerDriver.swift
+++ b/Sources/ThreeDSecure/ThreeDSecureSFSafariViewControllerDriver.swift
@@ -21,6 +21,7 @@ public class ThreeDSecureSFSafariViewControllerDriver: NSObject, ThreeDSecureWeb
         let safariVc = SFSafariViewController(url: url)
         safariVc.dismissButtonStyle = .close
         safariVc.delegate = self
+        safariVc.modalPresentationStyle = .overFullScreen
         self.delegate = delegate
         host.present(safariVc, animated: true, completion: nil)
     }

--- a/Sources/Views/CardFormScreenPresenter.swift
+++ b/Sources/Views/CardFormScreenPresenter.swift
@@ -28,7 +28,7 @@ protocol CardFormScreenDelegate: AnyObject {
 protocol CardFormScreenPresenterType {
     var cardFormResultSuccess: Bool { get }
 
-    func createToken(tenantId: String?, formInput: CardFormInput)
+    func createToken(tenantId: String?, useThreeDSecure: Bool, formInput: CardFormInput)
     func completeTokenTds()
     func fetchBrands(tenantId: String?)
     func tokenOperationStatusDidUpdate(status: TokenOperationStatus)
@@ -60,7 +60,7 @@ class CardFormScreenPresenter: CardFormScreenPresenterType {
         self.tokenOperationStatus = tokenService.tokenOperationObserver.status
     }
 
-    func createToken(tenantId: String?, formInput: CardFormInput) {
+    func createToken(tenantId: String?, useThreeDSecure: Bool, formInput: CardFormInput) {
         tokenizeProgressing = true
         updateIndicatingUI()
         tokenService.createToken(cardNumber: formInput.cardNumber,
@@ -70,7 +70,9 @@ class CardFormScreenPresenter: CardFormScreenPresenterType {
                                  name: formInput.cardHolder,
                                  tenantId: tenantId,
                                  email: formInput.email,
-                                 phone: formInput.phoneNumber) { [weak self] result in
+                                 phone: formInput.phoneNumber,
+                                 threeDSecure: useThreeDSecure
+        ) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let token):

--- a/Sources/Views/CardFormView.swift
+++ b/Sources/Views/CardFormView.swift
@@ -442,7 +442,7 @@ extension CardFormView: CardFormAction {
         return viewModel.isValid
     }
 
-    @nonobjc public func createToken(tenantId: String? = nil, useThreeDSecure: Bool, completion: @escaping (Result<Token, Error>) -> Void) {
+    @nonobjc public func createToken(tenantId: String? = nil, useThreeDSecure: Bool = false, completion: @escaping (Result<Token, Error>) -> Void) {
         viewModel.createToken(with: tenantId, useThreeDSecure: useThreeDSecure, completion: completion)
     }
 
@@ -462,7 +462,7 @@ extension CardFormView: CardFormAction {
         }
     }
 
-    @nonobjc public func fetchBrands(tenantId: String?, completion: CardBrandsResult?) {
+    @nonobjc public func fetchBrands(tenantId: String? = nil, completion: CardBrandsResult?) {
         viewModel.fetchAcceptedBrands(with: tenantId, completion: completion)
     }
 

--- a/Sources/Views/CardFormView.swift
+++ b/Sources/Views/CardFormView.swift
@@ -442,12 +442,16 @@ extension CardFormView: CardFormAction {
         return viewModel.isValid
     }
 
-    @nonobjc public func createToken(tenantId: String? = nil, completion: @escaping (Result<Token, Error>) -> Void) {
-        viewModel.createToken(with: tenantId, completion: completion)
+    @nonobjc public func createToken(tenantId: String? = nil, useThreeDSecure: Bool, completion: @escaping (Result<Token, Error>) -> Void) {
+        viewModel.createToken(with: tenantId, useThreeDSecure: useThreeDSecure, completion: completion)
     }
 
     public func createTokenWith(_ tenantId: String?, completion: @escaping (Token?, NSError?) -> Void) {
-        viewModel.createToken(with: tenantId) { [weak self] result in
+        return createTokenWith(tenantId, useThreeDSecure: false, completion: completion)
+    }
+
+    public func createTokenWith(_ tenantId: String?, useThreeDSecure: Bool, completion: @escaping (Token?, NSError?) -> Void) {
+        viewModel.createToken(with: tenantId, useThreeDSecure: useThreeDSecure) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let result):

--- a/Sources/Views/CardFormViewController.swift
+++ b/Sources/Views/CardFormViewController.swift
@@ -52,6 +52,7 @@ public class CardFormViewController: UIViewController {
 
     private var formStyle: FormStyle?
     private var tenantId: String?
+    private var useThreeDSecure: Bool = false
     private var cardFormViewType: CardFormViewType?
     private var accptedBrands: [CardBrand]?
     private var accessorySubmitButton: ActionButton!
@@ -71,14 +72,16 @@ public class CardFormViewController: UIViewController {
     ///   - delegate: delegate of CardFormViewControllerDelegate
     ///   - viewType: card form type
     ///   - extraAttributes: extra attributes for 3-D Secure
+    ///   - useThreeDSecure: whether use 3-D secure or not
     /// - Returns: CardFormViewController
-    @objc(createCardFormViewControllerWithStyle: tenantId: delegate: viewType: extraAttributes:)
+    @objc(createCardFormViewControllerWithStyle: tenantId: delegate: viewType: extraAttributes:useThreeDSecure:)
     public static func createCardFormViewController(
         style: FormStyle = .defaultStyle,
         tenantId: String? = nil,
         delegate: CardFormViewControllerDelegate,
         viewType: CardFormViewType = .labelStyled,
-        extraAttributes: [ExtraAttribute] = [ExtraAttributeEmail(), ExtraAttributePhone()]
+        extraAttributes: [ExtraAttribute] = [ExtraAttributeEmail(), ExtraAttributePhone()],
+        useThreeDSecure: Bool = false
     ) -> CardFormViewController {
 
         let stotyboard = UIStoryboard(name: "CardForm", bundle: .payjpBundle)
@@ -91,6 +94,7 @@ public class CardFormViewController: UIViewController {
         cardFormVc.delegate = delegate
         cardFormVc.cardFormViewType = viewType
         cardFormVc.extraAttributes = extraAttributes
+        cardFormVc.useThreeDSecure = useThreeDSecure
         return cardFormVc
     }
 
@@ -232,7 +236,7 @@ public class CardFormViewController: UIViewController {
         cardFormView.cardFormInput { result in
             switch result {
             case .success(let formInput):
-                presenter?.createToken(tenantId: tenantId, formInput: formInput)
+                presenter?.createToken(tenantId: tenantId, useThreeDSecure: useThreeDSecure, formInput: formInput)
             case .failure(let error):
                 showError(message: error.localizedDescription)
             }

--- a/Sources/Views/CardFormViewDelegate.swift
+++ b/Sources/Views/CardFormViewDelegate.swift
@@ -35,15 +35,17 @@ public protocol CardFormAction {
     ///
     /// - Parameters:
     ///   - tenantId: identifier of tenant
+    ///   - useThreeDSecure: Whether use 3-D secure or not
     ///   - completion: completion action
-    func createToken(tenantId: String?, completion: @escaping (Result<Token, Error>) -> Void)
+    func createToken(tenantId: String?, useThreeDSecure: Bool, completion: @escaping (Result<Token, Error>) -> Void)
 
     /// Create token for objective-c
     ///
     /// - Parameters:
     ///   - tenantId: identifier of tenant
+    ///   - useThreeDSecure: Whether use 3-D secure or not
     ///   - completion: completion action
-    func createTokenWith(_ tenantId: String?, completion: @escaping (Token?, NSError?) -> Void)
+    func createTokenWith(_ tenantId: String?, useThreeDSecure: Bool, completion: @escaping (Token?, NSError?) -> Void)
 
     /// Fetch accepted card brands for swift
     ///

--- a/Sources/Views/CardFormViewViewModel.swift
+++ b/Sources/Views/CardFormViewViewModel.swift
@@ -69,8 +69,9 @@ protocol CardFormViewViewModelType {
     ///
     /// - Parameters:
     ///   - tenantId: テナントID
+    ///   - useThreeDSecure: 3-D セキュアを利用するかどうか
     ///   - completion: 取得結果
-    func createToken(with tenantId: String?, completion: @escaping (Result<Token, Error>) -> Void)
+    func createToken(with tenantId: String?, useThreeDSecure: Bool, completion: @escaping (Result<Token, Error>) -> Void)
 
     /// 利用可能ブランドを取得する
     ///
@@ -296,7 +297,7 @@ class CardFormViewViewModel: CardFormViewViewModelType {
         return .success(formattedValue)
     }
 
-    func createToken(with tenantId: String?, completion: @escaping (Result<Token, Error>) -> Void) {
+    func createToken(with tenantId: String?, useThreeDSecure: Bool, completion: @escaping (Result<Token, any Error>) -> Void) {
         if let cardNumberString = cardNumber?.value, let month = monthYear?.month,
            let year = monthYear?.year, let cvc = cvc {
             tokenService.createToken(cardNumber: cardNumberString,
@@ -306,7 +307,9 @@ class CardFormViewViewModel: CardFormViewViewModelType {
                                      name: cardHolder,
                                      tenantId: tenantId,
                                      email: email,
-                                     phone: phoneNumber) { result in
+                                     phone: phoneNumber,
+                                     threeDSecure: useThreeDSecure
+            ) { result in
                 switch result {
                 case .success(let token): completion(.success(token))
                 case .failure(let error): completion(.failure(error))

--- a/Tests/APIClientTests.swift
+++ b/Tests/APIClientTests.swift
@@ -95,6 +95,9 @@ class APIClientTests: XCTestCase {
         let cardCvc = "123"
         let cardHolderName = "TARO YAMADA"
         let tenantId = "ten_123"
+        let email = "test@example.com"
+        let phone = "+819012345678"
+        let useThreeDSecure = true
 
         HTTPStubs.removeAllStubs()
         stubCardInputResponse(cardNumber: cardNumber,
@@ -103,6 +106,9 @@ class APIClientTests: XCTestCase {
                               cardExpYear: cardExpYear,
                               cardHolderName: cardHolderName,
                               tenantId: tenantId,
+                              email: "test%40example.com", // URLEncoded
+                              phone: "%2B819012345678", // URLEncoded
+                              useThreeDSecure: useThreeDSecure,
                               json: json)
 
         let expectation = self.expectation(description: self.description)
@@ -112,7 +118,11 @@ class APIClientTests: XCTestCase {
                               expirationMonth: cardExpMonth,
                               expirationYear: cardExpYear,
                               name: cardHolderName,
-                              tenantId: tenantId) { result in
+                              tenantId: tenantId,
+                              email: email,
+                              phone: phone,
+                              useThreeDSecure: useThreeDSecure
+        ) { result in
             switch result {
             case .success(let token):
                 XCTAssertEqual(token.identifer, expectedToken.identifer)
@@ -141,6 +151,9 @@ class APIClientTests: XCTestCase {
         let cardCvc = "123"
         let cardHolderName = "TARO YAMADA"
         let tenantId = "ten_123"
+        let email = "test@example.com"
+        let phone = "+819012345678"
+        let useThreeDSecure = true
 
         HTTPStubs.removeAllStubs()
         stubCardInputResponse(cardNumber: cardNumber,
@@ -149,6 +162,9 @@ class APIClientTests: XCTestCase {
                               cardExpYear: cardExpYear,
                               cardHolderName: cardHolderName,
                               tenantId: tenantId,
+                              email: "test%40example.com", // URLEncoded
+                              phone: "%2B819012345678", // URLEncoded
+                              useThreeDSecure: useThreeDSecure,
                               json: json)
 
         let expectation = self.expectation(description: self.description)
@@ -158,7 +174,11 @@ class APIClientTests: XCTestCase {
                                   expirationMonth: cardExpMonth,
                                   expirationYear: cardExpYear,
                                   name: cardHolderName,
-                                  tenantId: tenantId) { (token, error) in
+                                  tenantId: tenantId,
+                                  email: email,
+                                  phone: phone,
+                                  useThreeDSecure: useThreeDSecure
+        ) { (token, error) in
             XCTAssertNil(error)
             guard let token = token else {
                 XCTFail()
@@ -338,6 +358,9 @@ class APIClientTests: XCTestCase {
                                        cardExpYear: String,
                                        cardHolderName: String,
                                        tenantId: String,
+                                       email: String,
+                                       phone: String,
+                                       useThreeDSecure: Bool,
                                        json: Data) {
         let cardHolderNameEncoded = cardHolderName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
         stub(condition: { (req) -> Bool in
@@ -358,6 +381,9 @@ class APIClientTests: XCTestCase {
                 XCTAssertEqual(body?["card%5Bexp_year%5D"], cardExpYear)
                 XCTAssertEqual(body?["card%5Bname%5D"], cardHolderNameEncoded)
                 XCTAssertEqual(body?["tenant"], tenantId)
+                XCTAssertEqual(body?["card%5Bemail%5D"], email)
+                XCTAssertEqual(body?["card%5Bphone%5D"], phone)
+                XCTAssertEqual(body?["three_d_secure"], String(useThreeDSecure))
                 return true
             }
             return false

--- a/Tests/Networking/Requests/CreateTokenRequestTests.swift
+++ b/Tests/Networking/Requests/CreateTokenRequestTests.swift
@@ -19,7 +19,8 @@ class CreateTokenRequestTests: XCTestCase {
             name: "YUI ARAGAKI",
             tenantId: "mock_tenant_id",
             email: "test@example.com",
-            phone: "+819012345678"
+            phone: "+819012345678",
+            threeDSecure: true
         )
 
         XCTAssertEqual(request.path, "tokens")
@@ -32,6 +33,7 @@ class CreateTokenRequestTests: XCTestCase {
         XCTAssertEqual(request.bodyParameters?["tenant"], "mock_tenant_id")
         XCTAssertEqual(request.bodyParameters?["card[email]"], "test@example.com")
         XCTAssertEqual(request.bodyParameters?["card[phone]"], "+819012345678")
+        XCTAssertEqual(request.bodyParameters?["three_d_secure"], "true")
         XCTAssertNil(request.queryParameters)
     }
 
@@ -45,7 +47,8 @@ class CreateTokenRequestTests: XCTestCase {
             name: nil,
             tenantId: nil,
             email: nil,
-            phone: nil
+            phone: nil,
+            threeDSecure: false
         )
 
         XCTAssertEqual(request.path, "tokens")
@@ -58,6 +61,7 @@ class CreateTokenRequestTests: XCTestCase {
         XCTAssertNil(request.bodyParameters?["tenant"])
         XCTAssertNil(request.bodyParameters?["card[email]"])
         XCTAssertNil(request.bodyParameters?["card[phone]"])
+        XCTAssertEqual(request.bodyParameters?["three_d_secure"], "false")
         XCTAssertNil(request.queryParameters)
     }
 }

--- a/Tests/Views/CardFormScreenPresenterTests.swift
+++ b/Tests/Views/CardFormScreenPresenterTests.swift
@@ -55,7 +55,7 @@ class CardFormScreenPresenterTests: XCTestCase {
         mockService.createTokenResult = .success(mockToken())
 
         let presenter = CardFormScreenPresenter(delegate: mockDelegate, tokenService: mockService)
-        presenter.createToken(tenantId: "tenant_id", formInput: cardFormInput())
+        presenter.createToken(tenantId: "tenant_id", useThreeDSecure: true, formInput: cardFormInput())
         presenter.tokenOperationStatusDidUpdate(status: .running)
         presenter.tokenOperationStatusDidUpdate(status: .throttled)
         presenter.tokenOperationStatusDidUpdate(status: .acceptable)
@@ -84,7 +84,7 @@ class CardFormScreenPresenterTests: XCTestCase {
         mockService.createTokenResult = .failure(apiError)
 
         let presenter = CardFormScreenPresenter(delegate: mockDelegate, tokenService: mockService)
-        presenter.createToken(tenantId: "tenant_id", formInput: cardFormInput())
+        presenter.createToken(tenantId: "tenant_id", useThreeDSecure: true, formInput: cardFormInput())
         presenter.tokenOperationStatusDidUpdate(status: .running)
         presenter.tokenOperationStatusDidUpdate(status: .throttled)
 
@@ -114,7 +114,7 @@ class CardFormScreenPresenterTests: XCTestCase {
         mockService.createTokenResult = .success(mockToken())
 
         let presenter = CardFormScreenPresenter(delegate: mockDelegate, tokenService: mockService)
-        presenter.createToken(tenantId: "tenant_id", formInput: cardFormInput())
+        presenter.createToken(tenantId: "tenant_id", useThreeDSecure: true, formInput: cardFormInput())
         presenter.tokenOperationStatusDidUpdate(status: .running)
         presenter.tokenOperationStatusDidUpdate(status: .throttled)
 
@@ -185,7 +185,7 @@ class CardFormScreenPresenterTests: XCTestCase {
         mockService.createTokenResult = .success(token)
 
         let presenter = CardFormScreenPresenter(delegate: mockDelegate, tokenService: mockService)
-        presenter.createToken(tenantId: "tenant_id", formInput: cardFormInput())
+        presenter.createToken(tenantId: "tenant_id", useThreeDSecure: true, formInput: cardFormInput())
         presenter.tokenOperationStatusDidUpdate(status: .running)
         presenter.tokenOperationStatusDidUpdate(status: .throttled)
         presenter.tokenOperationStatusDidUpdate(status: .acceptable)
@@ -211,7 +211,7 @@ class CardFormScreenPresenterTests: XCTestCase {
 
         let presenter = CardFormScreenPresenter(delegate: mockDelegate,
                                                 tokenService: mockService)
-        presenter.createToken(tenantId: "tenant_id", formInput: cardFormInput())
+        presenter.createToken(tenantId: "tenant_id", useThreeDSecure: true, formInput: cardFormInput())
         presenter.completeTokenTds()
         presenter.tokenOperationStatusDidUpdate(status: .running)
         presenter.tokenOperationStatusDidUpdate(status: .throttled)
@@ -242,7 +242,7 @@ class CardFormScreenPresenterTests: XCTestCase {
 
         let presenter = CardFormScreenPresenter(delegate: mockDelegate,
                                                 tokenService: mockService)
-        presenter.createToken(tenantId: "tenant_id", formInput: cardFormInput())
+        presenter.createToken(tenantId: "tenant_id", useThreeDSecure: true, formInput: cardFormInput())
         presenter.completeTokenTds()
 
         waitForExpectations(timeout: 1, handler: nil)

--- a/Tests/Views/Mock.swift
+++ b/Tests/Views/Mock.swift
@@ -95,16 +95,17 @@ class MockTokenService: TokenServiceType {
     let tokenOperationObserver: TokenOperationObserverType = MockTokenOperationObserverType()
 
     // swiftlint:disable function_parameter_count
-    func createToken(cardNumber: String,
-                     cvc: String,
-                     expirationMonth: String,
-                     expirationYear: String,
-                     name: String?,
-                     tenantId: String?,
-                     email: String?,
-                     phone: String?,
-                     completion: @escaping (Result<Token, APIError>) -> Void) -> URLSessionDataTask? {
-
+    func createToken(
+        cardNumber: String,
+        cvc: String,
+        expirationMonth: String,
+        expirationYear: String,
+        name: String?,
+        tenantId: String?,
+        email: String?,
+        phone: String?,
+        threeDSecure: Bool,
+        completion: @escaping (Result<Token, APIError>) -> Void) -> URLSessionDataTask? {
         self.createTokenTenantId = tenantId
         guard let result = createTokenResult else {
             fatalError("Set createTokenResult before invoked.")

--- a/example-objc/example-objc/CardFormViewExampleViewController.m
+++ b/example-objc/example-objc/CardFormViewExampleViewController.m
@@ -171,6 +171,7 @@
 
   [self.cardFormView
       createTokenWith:nil
+      useThreeDSecure:YES
            completion:^(PAYToken *token, NSError *error) {
              if (error.domain == PAYErrorDomain && error.code == PAYErrorServiceError) {
                id<PAYErrorResponseType> errorResponse = error.userInfo[PAYErrorServiceErrorObject];

--- a/example-objc/example-objc/CardFormViewScrollViewController.m
+++ b/example-objc/example-objc/CardFormViewScrollViewController.m
@@ -188,6 +188,7 @@
 
   [self.cardFormView
       createTokenWith:nil
+      useThreeDSecure:YES
            completion:^(PAYToken *token, NSError *error) {
              if (error.domain == PAYErrorDomain && error.code == PAYErrorServiceError) {
                id<PAYErrorResponseType> errorResponse = error.userInfo[PAYErrorServiceErrorObject];

--- a/example-objc/example-objc/ExampleHostViewController.m
+++ b/example-objc/example-objc/ExampleHostViewController.m
@@ -54,7 +54,8 @@
                                                               tenantId:nil
                                                               delegate:self
                                                               viewType:viewType
-                                                       extraAttributes:@[ email, phone ]];
+                                                       extraAttributes:@[ email, phone ]
+                                                       useThreeDSecure:YES];
   [self.navigationController pushViewController:cardFormVc animated:YES];
 }
 
@@ -67,7 +68,8 @@
                                                               tenantId:nil
                                                               delegate:self
                                                               viewType:viewType
-                                                       extraAttributes:@[ email, phone ]];
+                                                       extraAttributes:@[ email, phone ]
+                                                       useThreeDSecure:YES];
   UINavigationController *naviVc =
       [UINavigationController.new initWithRootViewController:cardFormVc];
   naviVc.presentationController.delegate = cardFormVc;

--- a/example-objc/example-objc/ViewController.m
+++ b/example-objc/example-objc/ViewController.m
@@ -58,6 +58,9 @@
                      expirationYear:year
                                name:name
                            tenantId:nil
+                              email:nil
+                              phone:nil
+                    useThreeDSecure:NO
                   completionHandler:^(PAYToken *token, NSError *error) {
                     if (error.domain == PAYErrorDomain && error.code == PAYErrorServiceError) {
                       id<PAYErrorResponseType> errorResponse =

--- a/example-swift/example-swift/CardFormViewExampleViewController.swift
+++ b/example-swift/example-swift/CardFormViewExampleViewController.swift
@@ -189,7 +189,7 @@ class CardFormVieExampleViewController: UITableViewController, CardFormViewDeleg
     }
 
     func createToken() {
-        self.cardFormView.createToken(tenantId: "tenant_id") { [weak self] result in
+        self.cardFormView.createToken(useThreeDSecure: true) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let token):
@@ -212,7 +212,7 @@ class CardFormVieExampleViewController: UITableViewController, CardFormViewDeleg
     }
 
     func fetchBrands() {
-        self.cardFormView.fetchBrands(tenantId: "tenant_id") { [weak self] result in
+        self.cardFormView.fetchBrands { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let brands):

--- a/example-swift/example-swift/CardFormViewScrollViewController.swift
+++ b/example-swift/example-swift/CardFormViewScrollViewController.swift
@@ -167,7 +167,7 @@ class CardFormViewScrollViewController: UIViewController, CardFormViewDelegate,
     }
 
     func createToken() {
-        self.cardFormView.createToken(tenantId: "tenant_id") { [weak self] result in
+        self.cardFormView.createToken(useThreeDSecure: true) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let token):
@@ -189,7 +189,7 @@ class CardFormViewScrollViewController: UIViewController, CardFormViewDelegate,
     }
 
     func fetchBrands() {
-        self.cardFormView.fetchBrands(tenantId: "tenant_id") { [weak self] result in
+        self.cardFormView.fetchBrands { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let brands):

--- a/example-swift/example-swift/CardFormViewWith3DSViewController.swift
+++ b/example-swift/example-swift/CardFormViewWith3DSViewController.swift
@@ -60,7 +60,7 @@ class CardFormViewWith3DSViewController: UIViewController {
     }
 
     func createToken() {
-        self.cardFormView.createToken { [weak self] result in
+        self.cardFormView.createToken(useThreeDSecure: true) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let token):

--- a/example-swift/example-swift/ExampleHostViewController.swift
+++ b/example-swift/example-swift/ExampleHostViewController.swift
@@ -28,7 +28,7 @@ class ExampleHostViewController: UITableViewController {
 
     private func presentTdsAttributeOptions(viewType: CardFormViewType, pushNavigation: Bool) {
         func showCardForm(attributes: [ExtraAttribute]) {
-            let cardForm = CardFormViewController.createCardFormViewController(delegate: self, viewType: viewType, extraAttributes: attributes)
+            let cardForm = CardFormViewController.createCardFormViewController(delegate: self, viewType: viewType, extraAttributes: attributes, useThreeDSecure: true)
             if pushNavigation {
                 self.navigationController?.pushViewController(cardForm, animated: true)
             } else {


### PR DESCRIPTION
POST /v1/tokens をリクエストする際に three_d_secure パラメータを追加します。

## CardFormViewController
- `CardFormViewController.createCardFormViewController(style:tenantId:delegate:viewType:extraAttributes:)` に `useThreeDSecure` という Bool 型の引数を追加します。デフォルトは false です。
- 3Dセキュアのブラウザを閉じる際にうまくハンドリングできない問題を修正しています。

```diff
 let cardForm = CardFormViewController.createCardFormViewController(
     delegate: self,
     viewType: viewType,
     extraAttributes: attributes,
+    useThreeDSecure: true
)
```

## CardFormView
- `CardFormView.createToken(tenantId:completion:)` に `useThreeDSecure` という Bool 型の引数を追加します。デフォルトは false です。

