### PR TITLE
Flutter用のpodspecがlintが壊れて配布できていなかったのを修正

### DIFF
--- a/PAYJPFlutterCore.podspec
+++ b/PAYJPFlutterCore.podspec
@@ -10,7 +10,7 @@ require './podspec'
 Pod::Spec.new do |s|
   s.name             = 'PAYJPFlutterCore'
   s.version          = PAYJPSDK::VERSION
-  s.summary          = 'PAY.JP iOS SDK for Flutter distribution'
+  s.summary          = 'PAY.JP iOS SDK for Flutter'
   s.description      = 'PAY.JP iOS SDK https://pay.jp/docs'
 
   s.homepage         = PAYJPSDK::HOMEPAGE_URL

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,8 +38,8 @@ platform :ios do
 
   desc "Lint podspec"
   lane :lint_podspec do
-    sh('pod lib lint ../PAYJP.podspec --allow-warnings')
-    sh('pod lib lint ../PAYJPFlutterCore.podspec --allow-warnings')
+    sh('pod lib lint ../PAYJP.podspec')
+    sh('pod lib lint ../PAYJPFlutterCore.podspec')
     pod_version = PAYJPSDK::VERSION
     info_version = get_version_number
     unless pod_version == info_version then


### PR DESCRIPTION
> WARN  | description: The description is shorter than the summary.
> https://github.com/payjp/payjp-ios/actions/runs/11789013169/job/32837055966

- #84 でsummaryの方がdescriptionよりも長くなった
- CIのlintではwarningは許容していたので pass していた
- trunk への登録はwarningを許容していなかったので落ちていた
- summaryの方が短くなるように調整
- CIでもwarningを許容しないように
