### PR TITLE
エラーメッセージが省略されてしまうのを修正

### DIFF
--- a/Sources/Views/CardFormDisplayStyledView.swift
+++ b/Sources/Views/CardFormDisplayStyledView.swift
@@ -272,6 +272,7 @@ public class CardFormDisplayStyledView: CardFormView, CardFormProperties {
     private func setupErrorLabel() -> UILabel {
         let label = UILabel()
         label.font = .systemFont(ofSize: 13)
+        label.numberOfLines = 0
         return label
     }
 
@@ -517,9 +518,6 @@ public class CardFormDisplayStyledView: CardFormView, CardFormProperties {
         contentStackView.addArrangedSubview(phoneNumberErrorLabel)
 
         NSLayoutConstraint.activate([
-            cardHolderErrorLabel.heightAnchor.constraint(equalToConstant: 20.0),
-            emailErrorLabel.heightAnchor.constraint(equalToConstant: 20.0),
-            phoneNumberErrorLabel.heightAnchor.constraint(equalToConstant: 20.0),
             cardHolderStackView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),
             cardHolderStackView.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor),
             extrasStackView.leadingAnchor.constraint(equalTo: contentStackView.leadingAnchor),


### PR DESCRIPTION
|before|after|
|-|-|
|<img src=https://github.com/user-attachments/assets/79bd808c-646e-4366-beef-c0ef5004e42c width=300 />|<img src=https://github.com/user-attachments/assets/40463520-90e9-4934-b685-96e0a35a070e width=300 />|
