### PR TITLE
カードフォーム画面で利用可能ブランドによるカード番号バリデーションが実施されないのを修正

### DIFF
--- a/Sources/Views/CardFormView.swift
+++ b/Sources/Views/CardFormView.swift
@@ -299,6 +299,10 @@ public class CardFormView: UIView {
         inputPhoneNumberComplete()
     }
 
+    func setAcceptedBrands(_ brands: [CardBrand]) {
+        viewModel.setAcceptedCardBrands(brands)
+    }
+
     func inputCardNumberSuccess(value: CardNumber) {
         cardFormProperties.cardNumberErrorLabel.text = nil
     }

--- a/Sources/Views/CardFormViewController.swift
+++ b/Sources/Views/CardFormViewController.swift
@@ -297,6 +297,7 @@ extension CardFormViewController: CardFormScreenDelegate {
 
     func reloadBrands(brands: [CardBrand]) {
         accptedBrands = brands
+        cardFormView.setAcceptedBrands(brands)
         brandsView.reloadData()
     }
 

--- a/Sources/Views/CardFormViewViewModel.swift
+++ b/Sources/Views/CardFormViewViewModel.swift
@@ -80,6 +80,10 @@ protocol CardFormViewViewModelType {
     ///   - completion: 取得結果
     func fetchAcceptedBrands(with tenantId: String?, completion: CardBrandsResult?)
 
+    /// 利用可能ブランドをセットする
+    /// - Parameter brands: 利用可能ブランド
+    func setAcceptedCardBrands(_ brands: [CardBrand])
+
     /// フォームの入力値を取得する
     /// - Parameter completion: 取得結果
     func cardFormInput(completion: (Result<CardFormInput, Error>) -> Void)
@@ -340,6 +344,10 @@ class CardFormViewViewModel: CardFormViewViewModelType {
                 completion?(.failure(error))
             }
         }
+    }
+
+    func setAcceptedCardBrands(_ brands: [CardBrand]) {
+        self.acceptedCardBrands = brands
     }
 
     func cardFormInput(completion: (Result<CardFormInput, Error>) -> Void) {

--- a/Sources/Views/CardFormViewViewModel.swift
+++ b/Sources/Views/CardFormViewViewModel.swift
@@ -188,7 +188,7 @@ class CardFormViewViewModel: CardFormViewViewModelType {
             // 利用可能ブランドのチェック
             if let acceptedCardBrands = self.acceptedCardBrands {
                 if cardNumberInput.brand != .unknown && !acceptedCardBrands.contains(cardNumberInput.brand) {
-                    return .failure(.cardNumberInvalidError(value: cardNumberInput, isInstant: false))
+                    return .failure(.cardNumberInvalidBrandError(value: cardNumberInput, isInstant: true))
                 }
             }
             // 桁数チェック


### PR DESCRIPTION
#92 の対応

## 何が問題か

- カード番号のバリデーションで利用可能なブランドかどうかのチェックはブランド未取得だとスキップする
- CardFormViewは明示的に fetchBrands(tenantId:completion:) を呼ばないと利用可能なブランドを取得しない
- CardFormViewController （[カードフォーム画面](https://pay.jp/docs/mobileapp-ios#use-card-form-controller)のViewController）は利用可能ブランドの表示はするが、CardFormView の fetchBrands(tenantId:completion:) は呼び出してなかったので、バリデーションされない状態にあった

## どうしたか

- 基本的には利用可能ブランドの取得は CardFormViewController 側ですでに実施しているので
- ブランド取得後に CardFormView にセットするように変更した
