### PR TITLE
「支払い時」「顧客カードに対する3Dセキュア」に対応

### DIFF
--- a/PAYJP.xcodeproj/project.pbxproj
+++ b/PAYJP.xcodeproj/project.pbxproj
@@ -7,13 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07AEC1332D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AEC1322D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift */; };
+		07BC10742D4625CB00891977 /* PhoneNumberKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 328622622C6C42CB00DEA55B /* PhoneNumberKit.xcframework */; };
 		32167E0727B1C55800E4BCD5 /* OHHTTPStubs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0627B1C55800E4BCD5 /* OHHTTPStubs.xcframework */; };
 		322BD1D6225C83CA00D83B5E /* JSONDecoder+PAYJP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322BD1D5225C83CA00D83B5E /* JSONDecoder+PAYJP.swift */; };
 		32585BAF2CAC4E7C003F920B /* CardHolderValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32585BAE2CAC4E7C003F920B /* CardHolderValidator.swift */; };
 		32585BB22CAC5237003F920B /* CardHolderValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32585BB02CAC522B003F920B /* CardHolderValidatorTests.swift */; };
 		325E36B1233484C90037E6BE /* UIColor+PAYJP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325E36B0233484C90037E6BE /* UIColor+PAYJP.swift */; };
 		327C806E2C73D1F700CADF44 /* ExtraAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327C806D2C73D1F700CADF44 /* ExtraAttribute.swift */; };
-		328622662C6C483F00DEA55B /* PhoneNumberKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 328622622C6C42CB00DEA55B /* PhoneNumberKit.xcframework */; };
 		3289C9D123EACB6D008FFBC1 /* ClientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3289C9D023EACB6D008FFBC1 /* ClientInfo.swift */; };
 		3289C9D323EBFC87008FFBC1 /* ClientInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3289C9D223EBFC87008FFBC1 /* ClientInfoTests.swift */; };
 		32A6F614239608DD00747477 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A6F613239608DD00747477 /* ActionButton.swift */; };
@@ -152,8 +153,21 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		07BC10762D4625CB00891977 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
-		320B38E92C6E3886002D1BFB /* PAYJPTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = PAYJPTests.xctestplan; path = Tests/PAYJPTests.xctestplan; sourceTree = "<group>"; };
+		07AEC1322D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecureURLConfigurationTests.swift; sourceTree = "<group>"; };
 		32167E0627B1C55800E4BCD5 /* OHHTTPStubs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OHHTTPStubs.xcframework; path = Carthage/Build/OHHTTPStubs.xcframework; sourceTree = "<group>"; };
 		322BD1D5225C83CA00D83B5E /* JSONDecoder+PAYJP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+PAYJP.swift"; sourceTree = "<group>"; };
 		32585BAE2CAC4E7C003F920B /* CardHolderValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardHolderValidator.swift; sourceTree = "<group>"; };
@@ -225,7 +239,6 @@
 		C65513BD1DA37AD4009D6DA5 /* APIError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		C68681F61E1E21D9001D7F75 /* CardFromTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardFromTokenTests.swift; sourceTree = "<group>"; };
 		C68681F91E1E2369001D7F75 /* TestFixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestFixture.swift; sourceTree = "<group>"; };
-		C6E00B0D1E1F505600C101B0 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		ED00F8BE24319E1B004DFE2C /* UIApplication+PAYJP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+PAYJP.swift"; sourceTree = "<group>"; };
 		ED00F8CF243353FC004DFE2C /* ThreeDSecureProcessHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreeDSecureProcessHandler.swift; sourceTree = "<group>"; };
 		ED00F8D0243353FC004DFE2C /* ThreeDSecureURLConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreeDSecureURLConfiguration.swift; sourceTree = "<group>"; };
@@ -299,6 +312,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07BC10742D4625CB00891977 /* PhoneNumberKit.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,7 +321,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				32167E0727B1C55800E4BCD5 /* OHHTTPStubs.xcframework in Frameworks */,
-				328622662C6C483F00DEA55B /* PhoneNumberKit.xcframework in Frameworks */,
 				615AFF661C8C74A1003FB86F /* PAYJP.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -362,7 +375,6 @@
 		615AFF511C8C74A1003FB86F = {
 			isa = PBXGroup;
 			children = (
-				320B38E92C6E3886002D1BFB /* PAYJPTests.xctestplan */,
 				C6E00B0C1E1F505600C101B0 /* Frameworks */,
 				615AFF5C1C8C74A1003FB86F /* Products */,
 				615AFF5D1C8C74A1003FB86F /* Sources */,
@@ -635,7 +647,6 @@
 			children = (
 				328622622C6C42CB00DEA55B /* PhoneNumberKit.xcframework */,
 				32167E0627B1C55800E4BCD5 /* OHHTTPStubs.xcframework */,
-				C6E00B0D1E1F505600C101B0 /* OHHTTPStubs.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -684,6 +695,7 @@
 			children = (
 				EDA0E418243739C00083A5E0 /* ThreeDSecureProcessHandlerTests.swift */,
 				ED3DB9E1243ACD2B0065FC33 /* ThreeDSecureSFSafariViewControllerDriverTests.swift */,
+				07AEC1322D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift */,
 				ED3DB9DF243ACCBE0065FC33 /* Mock.swift */,
 			);
 			path = ThreeDSecure;
@@ -725,6 +737,7 @@
 				615AFF581C8C74A1003FB86F /* Headers */,
 				615AFF591C8C74A1003FB86F /* Resources */,
 				324792A72342FD9B00C86EFB /* Run SwiftLint */,
+				07BC10762D4625CB00891977 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -949,6 +962,7 @@
 				EDA3EE9B22E1CD9900D9A6C9 /* CardBrandTransformerTests.swift in Sources */,
 				ED508383231CC3B600C64A7F /* StringProtocol+PAYJPTests.swift in Sources */,
 				EDA77569238E4CB200162340 /* PublicKeyValidatorTests.swift in Sources */,
+				07AEC1332D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift in Sources */,
 				EDA0E4142435EBA80083A5E0 /* ThreeDSecureStatusTests.swift in Sources */,
 				EDA3EE8122DF1F0300D9A6C9 /* CardNumberFormatterTests.swift in Sources */,
 				BE21781622E8091A0098128D /* PAYJPSDKTests.swift in Sources */,

--- a/Sources/Networking/Models/Token.swift
+++ b/Sources/Networking/Models/Token.swift
@@ -88,25 +88,3 @@ extension Token {
         return false
     }
 }
-
-// MARK: - ThreeDSecure
-
-extension Token {
-    private var tdsBaseUrl: URL {
-        return URL(string: "\(PAYJPApiEndpoint)tds/\(identifer)")!
-    }
-
-    var tdsEntryUrl: URL {
-        let url = tdsBaseUrl.appendingPathComponent("start")
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
-        components.queryItems = [
-            URLQueryItem(name: "publickey", value: PAYJPSDK.publicKey),
-            URLQueryItem(name: "back", value: PAYJPSDK.threeDSecureURLConfiguration?.redirectURLKey)
-        ]
-        return components.url!
-    }
-
-    var tdsFinishUrl: URL {
-        return tdsBaseUrl.appendingPathComponent("finish")
-    }
-}

--- a/Sources/ThreeDSecure/ThreeDSecureURLConfiguration.swift
+++ b/Sources/ThreeDSecure/ThreeDSecureURLConfiguration.swift
@@ -19,4 +19,15 @@ public class ThreeDSecureURLConfiguration: NSObject {
         self.redirectURL = redirectURL
         self.redirectURLKey = redirectURLKey
     }
+
+    public func makeThreeDSecureEntryURL(resourceId: String) -> URL {
+        let baseUrl = URL(string: "\(PAYJPApiEndpoint)tds/\(resourceId)")!
+        let url = baseUrl.appendingPathComponent("start")
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
+        components.queryItems = [
+            URLQueryItem(name: "publickey", value: PAYJPSDK.publicKey),
+            URLQueryItem(name: "back", value: redirectURLKey)
+        ]
+        return components.url!
+    }
 }

--- a/Sources/Views/CardFormViewController.swift
+++ b/Sources/Views/CardFormViewController.swift
@@ -332,7 +332,7 @@ extension CardFormViewController: CardFormScreenDelegate {
     func presentVerificationScreen(token: Token) {
         ThreeDSecureProcessHandler.shared.startThreeDSecureProcess(viewController: self,
                                                                    delegate: self,
-                                                                   token: token)
+                                                                   resourceId: token.identifer)
     }
 
     func didCompleteCardForm(with result: CardFormResult) {

--- a/Tests/ThreeDSecure/ThreeDSecureProcessHandlerTests.swift
+++ b/Tests/ThreeDSecure/ThreeDSecureProcessHandlerTests.swift
@@ -33,7 +33,14 @@ class ThreeDSecureProcessHandlerTests: XCTestCase {
         return token
     }
 
+    private func mockResourceID() -> String {
+        return "ch_123"
+    }
+
+    @available(*, deprecated)
     func testStartThreeDSecureProcess() {
+        PAYJPSDK.threeDSecureURLConfiguration = ThreeDSecureURLConfiguration(redirectURL: URL(string: "test://")!,
+                                                                             redirectURLKey: "test")
         let mockDriver = MockWebDriver()
         let handler = ThreeDSecureProcessHandler(webDriver: mockDriver)
         let token = self.mockToken(tdsStatus: .unverified)
@@ -43,7 +50,22 @@ class ThreeDSecureProcessHandlerTests: XCTestCase {
                                          delegate: mockVC,
                                          token: token)
 
-        XCTAssertEqual(mockDriver.openWebBrowserUrl?.absoluteString, token.tdsEntryUrl.absoluteString)
+        let expectedUrl = PAYJPSDK.threeDSecureURLConfiguration?.makeThreeDSecureEntryURL(resourceId: token.identifer)
+        XCTAssertEqual(mockDriver.openWebBrowserUrl?.absoluteString, expectedUrl?.absoluteString)
+    }
+
+    func testStartThreeDSecureProcessWithResourceID() {
+        let mockDriver = MockWebDriver()
+        let handler = ThreeDSecureProcessHandler(webDriver: mockDriver)
+        let resourceID = self.mockResourceID()
+        let mockVC = MockViewController()
+
+        handler.startThreeDSecureProcess(viewController: mockVC,
+                                         delegate: mockVC,
+                                         resourceId: resourceID)
+
+        // Verify the URL contains the resource ID
+        XCTAssertTrue(mockDriver.openWebBrowserUrl?.absoluteString.contains(resourceID) ?? false)
     }
 
     func testCompleteThreeDSecureProcess() {
@@ -52,13 +74,13 @@ class ThreeDSecureProcessHandlerTests: XCTestCase {
 
         let mockDriver = MockWebDriver(isSafariVC: true)
         let handler = ThreeDSecureProcessHandler(webDriver: mockDriver)
-        let token = self.mockToken(tdsStatus: .unverified)
+        let resourceID = self.mockResourceID()
         let mockVC = MockViewController()
         let url = URL(string: "test://")!
 
         handler.startThreeDSecureProcess(viewController: mockVC,
                                          delegate: mockVC,
-                                         token: token)
+                                         resourceId: resourceID)
 
         let result = handler.completeThreeDSecureProcess(url: url)
 
@@ -72,13 +94,13 @@ class ThreeDSecureProcessHandlerTests: XCTestCase {
 
         let mockDriver = MockWebDriver(isSafariVC: true)
         let handler = ThreeDSecureProcessHandler(webDriver: mockDriver)
-        let token = self.mockToken(tdsStatus: .unverified)
+        let resourceID = self.mockResourceID()
         let mockVC = MockViewController()
         let url = URL(string: "unknown://")!
 
         handler.startThreeDSecureProcess(viewController: mockVC,
                                          delegate: mockVC,
-                                         token: token)
+                                         resourceId: resourceID)
 
         let result = handler.completeThreeDSecureProcess(url: url)
 
@@ -92,13 +114,13 @@ class ThreeDSecureProcessHandlerTests: XCTestCase {
 
         let mockDriver = MockWebDriver(isSafariVC: false)
         let handler = ThreeDSecureProcessHandler(webDriver: mockDriver)
-        let token = self.mockToken(tdsStatus: .unverified)
+        let resourceID = self.mockResourceID()
         let mockVC = MockViewController()
         let url = URL(string: "test://")!
 
         handler.startThreeDSecureProcess(viewController: mockVC,
                                          delegate: mockVC,
-                                         token: token)
+                                         resourceId: resourceID)
 
         let result = handler.completeThreeDSecureProcess(url: url)
 
@@ -112,12 +134,12 @@ class ThreeDSecureProcessHandlerTests: XCTestCase {
 
         let mockDriver = MockWebDriver(isSafariVC: true)
         let handler = ThreeDSecureProcessHandler(webDriver: mockDriver)
-        let token = self.mockToken(tdsStatus: .unverified)
+        let resourceID = self.mockResourceID()
         let mockVC = MockViewController()
 
         handler.startThreeDSecureProcess(viewController: mockVC,
                                          delegate: mockVC,
-                                         token: token)
+                                         resourceId: resourceID)
         // Webブラウザを閉じた場合を想定
         handler.webBrowseDidFinish(mockDriver)
 

--- a/Tests/ThreeDSecure/ThreeDSecureURLConfigurationTests.swift
+++ b/Tests/ThreeDSecure/ThreeDSecureURLConfigurationTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import PAYJP
+
+class ThreeDSecureURLConfigurationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+
+        PAYJPSDK.publicKey = "public_key"
+    }
+
+    func testMakeThreeDSecureEntryURL() {
+        let redirectURL = URL(string: "test://")!
+        let redirectURLKey = "test"
+        let configuration = ThreeDSecureURLConfiguration(redirectURL: redirectURL, redirectURLKey: redirectURLKey)
+        let resourceId = "ch_123"
+        let expectedUrlString = "\(PAYJPApiEndpoint)tds/\(resourceId)/start?publickey=\(PAYJPSDK.publicKey!)&back=\(redirectURLKey)"
+        let threeDSecureEntryURL = configuration.makeThreeDSecureEntryURL(resourceId: resourceId)
+
+        XCTAssertEqual(threeDSecureEntryURL.absoluteString, expectedUrlString)
+    }
+}

--- a/example-objc/example-objc.xcodeproj/project.pbxproj
+++ b/example-objc/example-objc.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07EFF5F92D5BA99700E66DAD /* ThreeDSecureExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 07EFF5F82D5BA99700E66DAD /* ThreeDSecureExampleViewController.m */; };
 		32CB11691FDA97A1007AD8F5 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CB11681FDA97A1007AD8F5 /* AppDelegate.m */; };
 		32CB116C1FDA97A1007AD8F5 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CB116B1FDA97A1007AD8F5 /* ViewController.m */; };
 		32CB11711FDA97A1007AD8F5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 32CB11701FDA97A1007AD8F5 /* Assets.xcassets */; };
@@ -22,7 +23,48 @@
 		EDADA25E238B9DE60057FDF3 /* SampleService.m in Sources */ = {isa = PBXBuildFile; fileRef = EDADA25D238B9DE60057FDF3 /* SampleService.m */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		0777C9172D4A746B00D90CFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 5D5DCB4D5FD7F25FA86BF45E27546AC6;
+			remoteInfo = PAYJP;
+		};
+		0777C9192D4A746B00D90CFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9B9004C28064E22540CFEB2BBE5D815D;
+			remoteInfo = "PAYJP-PAYJP";
+		};
+		0777C91B2D4A746B00D90CFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 69681285C13FB58876DD5727BCB2DC85;
+			remoteInfo = PhoneNumberKit;
+		};
+		0777C91D2D4A746B00D90CFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 45D025E797F561FE08B0D339D021BCCD;
+			remoteInfo = "PhoneNumberKit-PhoneNumberKitPrivacy";
+		};
+		0777C91F2D4A746B00D90CFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 6FDD3DCEA8973F11FFD8BD6C6C9B89E7;
+			remoteInfo = "Pods-example-objc";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Pods.xcodeproj; sourceTree = "<group>"; };
+		07EFF5F72D5BA99700E66DAD /* ThreeDSecureExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreeDSecureExampleViewController.h; sourceTree = "<group>"; };
+		07EFF5F82D5BA99700E66DAD /* ThreeDSecureExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ThreeDSecureExampleViewController.m; sourceTree = "<group>"; };
 		0C330AD1C4F19804D88FF08A /* Pods-example-objc.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-example-objc.release.xcconfig"; path = "Target Support Files/Pods-example-objc/Pods-example-objc.release.xcconfig"; sourceTree = "<group>"; };
 		32CB11641FDA97A1007AD8F5 /* example-objc.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-objc.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		32CB11671FDA97A1007AD8F5 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -71,6 +113,18 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		0777C9102D4A746A00D90CFD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0777C9182D4A746B00D90CFD /* PAYJP.framework */,
+				0777C91A2D4A746B00D90CFD /* PAYJP.bundle */,
+				0777C91C2D4A746B00D90CFD /* PhoneNumberKit.framework */,
+				0777C91E2D4A746B00D90CFD /* PhoneNumberKitPrivacy.bundle */,
+				0777C9202D4A746B00D90CFD /* Pods_example_objc.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		32CB115B1FDA97A1007AD8F5 = {
 			isa = PBXGroup;
 			children = (
@@ -79,7 +133,9 @@
 				7D1E977C41291B2B0E664566 /* Pods */,
 				076A1CE0860082B360166A12 /* Frameworks */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		32CB11651FDA97A1007AD8F5 /* Products */ = {
 			isa = PBXGroup;
@@ -113,6 +169,8 @@
 				32CB11761FDA97A1007AD8F5 /* main.m */,
 				ED4ACE1923850AA400349BBF /* UIViewController+Alert.h */,
 				ED4ACE1A23850BCA00349BBF /* UIViewController+Alert.m */,
+				07EFF5F72D5BA99700E66DAD /* ThreeDSecureExampleViewController.h */,
+				07EFF5F82D5BA99700E66DAD /* ThreeDSecureExampleViewController.m */,
 			);
 			path = "example-objc";
 			sourceTree = "<group>";
@@ -120,6 +178,7 @@
 		7D1E977C41291B2B0E664566 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */,
 				50CBE7A2314A4BA81D8496FE /* Pods-example-objc.debug.xcconfig */,
 				0C330AD1C4F19804D88FF08A /* Pods-example-objc.release.xcconfig */,
 			);
@@ -175,12 +234,56 @@
 			mainGroup = 32CB115B1FDA97A1007AD8F5;
 			productRefGroup = 32CB11651FDA97A1007AD8F5 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 0777C9102D4A746A00D90CFD /* Products */;
+					ProjectRef = 0777C90F2D4A746A00D90CFD /* Pods.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				32CB11631FDA97A1007AD8F5 /* example-objc */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		0777C9182D4A746B00D90CFD /* PAYJP.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = PAYJP.framework;
+			remoteRef = 0777C9172D4A746B00D90CFD /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0777C91A2D4A746B00D90CFD /* PAYJP.bundle */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = PAYJP.bundle;
+			remoteRef = 0777C9192D4A746B00D90CFD /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0777C91C2D4A746B00D90CFD /* PhoneNumberKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = PhoneNumberKit.framework;
+			remoteRef = 0777C91B2D4A746B00D90CFD /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0777C91E2D4A746B00D90CFD /* PhoneNumberKitPrivacy.bundle */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = PhoneNumberKitPrivacy.bundle;
+			remoteRef = 0777C91D2D4A746B00D90CFD /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		0777C9202D4A746B00D90CFD /* Pods_example_objc.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Pods_example_objc.framework;
+			remoteRef = 0777C91F2D4A746B00D90CFD /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		32CB11621FDA97A1007AD8F5 /* Resources */ = {
@@ -252,6 +355,7 @@
 				BE0417D622E6DF6600B944CB /* CardFormViewExampleViewController.m in Sources */,
 				32CB11691FDA97A1007AD8F5 /* AppDelegate.m in Sources */,
 				EDADA25E238B9DE60057FDF3 /* SampleService.m in Sources */,
+				07EFF5F92D5BA99700E66DAD /* ThreeDSecureExampleViewController.m in Sources */,
 				ED50837D23167B9100C64A7F /* CardFormViewScrollViewController.m in Sources */,
 				ED4ACE1B23850BCA00349BBF /* UIViewController+Alert.m in Sources */,
 			);

--- a/example-objc/example-objc/Base.lproj/Main.storyboard
+++ b/example-objc/example-objc/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nTF-Oc-WpN">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nTF-Oc-WpN">
+    <device id="retina6_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,21 +14,21 @@
             <objects>
                 <tableViewController id="vBh-sw-9Ie" customClass="ExampleHostViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="x1g-Uw-NfB">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="440" height="956"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
-                            <tableViewSection id="f2J-H4-97A">
+                            <tableViewSection headerTitle="トークン作成 組み込み方法ごと" id="f2J-H4-97A">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="laI-N2-Rh7" style="IBUITableViewCellStyleDefault" id="5ZB-rO-ECd">
-                                        <rect key="frame" x="0.0" y="18" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="55.333332061767578" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5ZB-rO-ECd" id="C5C-PP-ZB1">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="409.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Card Form ViewController (Table)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="laI-N2-Rh7">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="381.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -37,14 +38,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="7Hv-N4-U8Z" style="IBUITableViewCellStyleDefault" id="a3m-Eo-2bC">
-                                        <rect key="frame" x="0.0" y="61.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="99" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="a3m-Eo-2bC" id="RYo-34-z5C">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="409.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Card Form ViewController (Label)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7Hv-N4-U8Z">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="381.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -54,14 +55,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="NUX-Ew-28s" style="IBUITableViewCellStyleDefault" id="uaS-ub-2xy">
-                                        <rect key="frame" x="0.0" y="105" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="142.66666793823242" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uaS-ub-2xy" id="dJp-TF-16f">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="409.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Card Form ViewController (Display)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NUX-Ew-28s">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="381.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -71,14 +72,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="PMl-4S-vLX" style="IBUITableViewCellStyleDefault" id="rP2-oW-81h">
-                                        <rect key="frame" x="0.0" y="148.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="186.33333587646484" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rP2-oW-81h" id="XTN-9S-di7">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="409.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Card Form Table Styled View" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PMl-4S-vLX">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="381.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -91,14 +92,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Wjs-DO-9wD" style="IBUITableViewCellStyleDefault" id="PPe-vf-fBh">
-                                        <rect key="frame" x="0.0" y="192" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="230.00000381469727" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PPe-vf-fBh" id="5uk-kw-vMh">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="409.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Card Form Label Styled View" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Wjs-DO-9wD">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="381.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -111,14 +112,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="pvm-Vu-6Mi" style="IBUITableViewCellStyleDefault" id="d4k-J2-4EB">
-                                        <rect key="frame" x="0.0" y="235.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="273.66667175292969" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="d4k-J2-4EB" id="0l4-PO-8JH">
-                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="409.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Request Directly" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pvm-Vu-6Mi">
-                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="381.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -128,6 +129,30 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="VKh-Lw-K9Y" kind="show" id="9Ie-5p-hfV"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="支払い時の3Dセキュア、または顧客カードの3Dセキュア" id="0tI-JY-xRC">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="a6s-A9-5eM" style="IBUITableViewCellStyleDefault" id="Ko4-8R-mbn">
+                                        <rect key="frame" x="0.0" y="373.33333778381348" width="440" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ko4-8R-mbn" id="vpi-iq-kav">
+                                            <rect key="frame" x="0.0" y="0.0" width="409.66666666666669" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="ThreeDSecureProcessHandler startThreeDSecureProcess" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="a6s-A9-5eM">
+                                                    <rect key="frame" x="20" y="0.0" width="381.66666666666669" height="43.666667938232422"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="kWv-Ei-ZdP" kind="show" id="3r8-Qc-7lt"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -149,7 +174,7 @@
             <objects>
                 <navigationController id="nTF-Oc-WpN" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="tS6-gH-3kN">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="62" width="440" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -165,21 +190,21 @@
             <objects>
                 <tableViewController title="Request Directly" id="VKh-Lw-K9Y" customClass="ViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="1hC-Zo-UoR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="440" height="956"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Card Information" id="U5z-sT-dp5">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="YSU-01-62O">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="55.333332061767578" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YSU-01-62O" id="9Hb-xh-FlF">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G25-Sq-rcs">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="20" y="11.333333333333336" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="Lco-P3-ER8"/>
                                                     </constraints>
@@ -188,7 +213,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="4242424242424242" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Exr-dr-g0q">
-                                                    <rect key="frame" x="159" y="13" width="200" height="19"/>
+                                                    <rect key="frame" x="224" y="12.333333333333336" width="200" height="19"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="V7z-I7-D3p"/>
                                                     </constraints>
@@ -206,14 +231,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="r2y-8c-RfI">
-                                        <rect key="frame" x="0.0" y="100" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="99" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r2y-8c-RfI" id="JJJ-yi-n11">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="cvc" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Fy-FG-QbM">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="20" y="11.333333333333336" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="7hE-7Y-jyS"/>
                                                     </constraints>
@@ -222,7 +247,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="123" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Lz7-lQ-qoo">
-                                                    <rect key="frame" x="159" y="13" width="200" height="19"/>
+                                                    <rect key="frame" x="224" y="12.333333333333336" width="200" height="19"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="dEi-22-Dji"/>
                                                     </constraints>
@@ -240,14 +265,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Ikw-Q6-9pM">
-                                        <rect key="frame" x="0.0" y="144.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="142.66666793823242" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ikw-Q6-9pM" id="ol4-wz-d6f">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="month" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEL-np-F3s">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="20" y="11.333333333333336" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="Fle-EG-TNb"/>
                                                     </constraints>
@@ -256,7 +281,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="12" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ySB-th-XuK">
-                                                    <rect key="frame" x="159" y="13" width="200" height="19"/>
+                                                    <rect key="frame" x="224" y="12.333333333333336" width="200" height="19"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="lGd-Dw-DD5"/>
                                                     </constraints>
@@ -274,14 +299,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="0zW-M9-7UY">
-                                        <rect key="frame" x="0.0" y="189" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="186.33333587646484" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0zW-M9-7UY" id="xk4-6g-NAk">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="year" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gIY-fC-7Is">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="20" y="11.333333333333336" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="dP2-1z-Hg5"/>
                                                     </constraints>
@@ -290,7 +315,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="2020" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="IQz-rn-7eQ">
-                                                    <rect key="frame" x="159" y="13" width="200" height="19"/>
+                                                    <rect key="frame" x="224" y="12.333333333333336" width="200" height="19"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="WdA-7E-p8e"/>
                                                     </constraints>
@@ -308,14 +333,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="yui-GT-tlk">
-                                        <rect key="frame" x="0.0" y="233.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="230.00000381469727" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yui-GT-tlk" id="yQN-pi-a4i">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8QM-3p-L9d">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="20" y="11.333333333333336" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="fSO-cd-Nnj"/>
                                                     </constraints>
@@ -324,7 +349,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="TARO YAMADA" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eND-j1-1x1">
-                                                    <rect key="frame" x="159" y="13" width="200" height="19"/>
+                                                    <rect key="frame" x="224" y="12.333333333333336" width="200" height="19"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="9HF-s3-CAR"/>
                                                     </constraints>
@@ -346,14 +371,14 @@
                             <tableViewSection id="a17-1D-eJy">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="TSV-5L-s1i" style="IBUITableViewCellStyleDefault" id="voI-jh-bsy">
-                                        <rect key="frame" x="0.0" y="314" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="309.66666984558105" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="voI-jh-bsy" id="PBQ-Ko-oP0">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Create Token" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TSV-5L-s1i">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="400" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -367,14 +392,14 @@
                             <tableViewSection headerTitle="last token id" footerTitle="Get token by token id. Fill it by creating token." id="QY1-9h-xy1">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="iSQ-BN-wpX" style="IBUITableViewCellStyleDefault" id="RTL-LH-MNd">
-                                        <rect key="frame" x="0.0" y="421" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="416.66666984558105" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RTL-LH-MNd" id="DIG-Xe-Fbj">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iSQ-BN-wpX">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="400" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -410,24 +435,24 @@
             <objects>
                 <tableViewController title="Card Form View" id="OBK-L6-feX" customClass="CardFormViewExampleViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="I1R-oF-FfK">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="440" height="956"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Card Information" id="kqf-49-3of">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="250" id="EaW-oQ-Agg">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="250"/>
+                                        <rect key="frame" x="0.0" y="55.333332061767578" width="440" height="250"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EaW-oQ-Agg" id="o5g-B2-T55">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="250"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="250"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="wlZ-ij-hx2">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="250"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="440" height="250"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="72d-mz-CTM" customClass="PAYCardFormTableStyledView">
-                                                            <rect key="frame" x="0.0" y="0.0" width="375" height="250"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="440" height="250"/>
                                                         </view>
                                                     </subviews>
                                                 </stackView>
@@ -447,14 +472,14 @@
                             <tableViewSection id="dlf-uk-QuC">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="XUl-Z5-Mmf" style="IBUITableViewCellStyleDefault" id="c6c-l5-GFl">
-                                        <rect key="frame" x="0.0" y="341.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="341.33333015441895" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c6c-l5-GFl" id="2Vh-7D-lYX">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Create Token" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XUl-Z5-Mmf">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="400" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -464,14 +489,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="WBk-1o-9kM" style="IBUITableViewCellStyleDefault" id="fhy-GU-cv1" userLabel="Create Token Anyway Button">
-                                        <rect key="frame" x="0.0" y="385" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="384.99999809265137" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fhy-GU-cv1" id="yM0-1L-mmc">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Validate Form and Create Token" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="WBk-1o-9kM">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="400" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -481,10 +506,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="MTf-yB-iWB" userLabel="Create Token Anyway Button">
-                                        <rect key="frame" x="0.0" y="428.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="428.66666603088379" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MTf-yB-iWB" id="0Oz-qm-aQL">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Select Color" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Cy7-tt-tBj">
@@ -502,14 +527,14 @@
                             <tableViewSection headerTitle="last token id" footerTitle="Get token by token id. Fill it by creating token." id="5pa-fi-Rv6">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="DNC-Pu-dxa" style="IBUITableViewCellStyleDefault" id="RbB-3k-qeA">
-                                        <rect key="frame" x="0.0" y="536.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="535.66666603088379" width="440" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RbB-3k-qeA" id="Qch-mM-Yd0">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DNC-Pu-dxa">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="400" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -544,52 +569,52 @@
             <objects>
                 <viewController title="Card Form View" id="yyD-Mo-wif" customClass="CardFormViewScrollViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="IVY-Tz-TeI">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="440" height="956"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="VFV-NB-jMz">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="440" height="956"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="esE-UU-05N">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="575.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="440" height="575.33333333333337"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uRA-zd-x0N" customClass="PAYCardFormLabelStyledView">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="339"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="440" height="339"/>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="UrL-qJ-wer">
-                                                <rect key="frame" x="0.0" y="347" width="375" height="228.5"/>
+                                                <rect key="frame" x="0.0" y="347" width="440" height="228.33333333333337"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lY7-bv-Jwq">
-                                                        <rect key="frame" x="16" y="8" width="343" height="30"/>
+                                                        <rect key="frame" x="16" y="8" width="408" height="30"/>
                                                         <state key="normal" title="Create Token"/>
                                                         <connections>
                                                             <action selector="createToken:" destination="yyD-Mo-wif" eventType="touchUpInside" id="B9t-IW-FTS"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xxu-Gk-Qdj">
-                                                        <rect key="frame" x="16" y="46" width="343" height="30"/>
+                                                        <rect key="frame" x="16" y="46" width="408" height="30"/>
                                                         <state key="normal" title="Validate Form And Create Token"/>
                                                         <connections>
                                                             <action selector="validateAndCreateToken:" destination="yyD-Mo-wif" eventType="touchUpInside" id="CcT-cQ-kX1"/>
                                                         </connections>
                                                     </button>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Select Color" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iWe-7X-jUk">
-                                                        <rect key="frame" x="16" y="84" width="343" height="34"/>
+                                                        <rect key="frame" x="16" y="84" width="408" height="34"/>
                                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits"/>
                                                     </textField>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="grH-gp-NrN">
-                                                        <rect key="frame" x="16" y="126" width="343" height="94.5"/>
+                                                        <rect key="frame" x="16" y="126" width="408" height="94.333333333333314"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="token id" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wP4-fN-NSH">
-                                                                <rect key="frame" x="0.0" y="8" width="343" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="7.9999999999999982" width="408" height="20.333333333333329"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8JZ-EV-iGf">
-                                                                <rect key="frame" x="0.0" y="36.5" width="343" height="50"/>
+                                                                <rect key="frame" x="0.0" y="36.333333333333314" width="408" height="50"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -637,10 +662,281 @@
             </objects>
             <point key="canvasLocation" x="249" y="958"/>
         </scene>
+        <!--3Dセキュア-->
+        <scene sceneID="H3D-1Y-ajd">
+            <objects>
+                <viewController id="kWv-Ei-ZdP" customClass="ThreeDSecureExampleViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="3Ma-Pa-sup">
+                        <rect key="frame" x="0.0" y="0.0" width="440" height="956"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="リソースIDを入力してください（ch_xxxx または tdsr_xx など）。" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PZ3-Dn-InO">
+                                <rect key="frame" x="20" y="126" width="400" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="fG6-Vc-KQp"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xyd-lX-2OW">
+                                <rect key="frame" x="20" y="170" width="400" height="90"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="90" id="kIS-os-q2h"/>
+                                </constraints>
+                                <string key="text">3Dセキュア認証が終了しました。
+この結果をサーバーサイドに伝え、完了処理や結果のハンドリングを行なってください。
+後続処理の実装方法に関してはドキュメントをご参照ください。</string>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bIy-sO-GDO">
+                                <rect key="frame" x="148" y="242.66666666666666" width="144" height="34.333333333333343"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="3Dセキュア開始"/>
+                                <connections>
+                                    <action selector="startThreeDSecure:" destination="kWv-Ei-ZdP" eventType="touchUpInside" id="ahJ-vd-f4e"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" usesAttributedText="YES" id="mfh-Dl-fHn">
+                                <rect key="frame" x="0.0" y="297" width="375" height="370"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="1.">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="下記を参考に、先にサーバーサイドで支払い、または">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュアリクエストを作成してください。">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cgo
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="支払い作成時の">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュア：">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="https://pay.jp/docs/charge-tds">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <url key="NSLink" string="https://pay.jp/docs/charge-tds"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cg
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="顧客カードに対する">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュア：">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cg
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="https://pay.jp/docs/customer-card-tds">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <url key="NSLink" string="https://pay.jp/docs/customer-card-tds"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content">
+
+2. </string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="作成したリソースの">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="ID">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="を上記に入力して">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュアを開始してください。">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content">
+
+3.立ち上がった画面が閉じ、認証が終了したら</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="、ドキュメントを参考にサーバーサイドにて結果を確認してください。">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <dataDetectorType key="dataDetectorTypes" link="YES"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="mpC-fA-tlI"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="PZ3-Dn-InO" firstAttribute="leading" secondItem="3Ma-Pa-sup" secondAttribute="leading" constant="20" id="0fw-jg-Ptl"/>
+                            <constraint firstItem="mpC-fA-tlI" firstAttribute="trailing" secondItem="xyd-lX-2OW" secondAttribute="trailing" constant="20" id="7W6-hN-DMb"/>
+                            <constraint firstItem="bIy-sO-GDO" firstAttribute="centerX" secondItem="mpC-fA-tlI" secondAttribute="centerX" id="An3-jX-1gy"/>
+                            <constraint firstItem="xyd-lX-2OW" firstAttribute="leading" secondItem="mpC-fA-tlI" secondAttribute="leading" constant="20" id="E3j-QA-1wg"/>
+                            <constraint firstItem="mfh-Dl-fHn" firstAttribute="top" secondItem="bIy-sO-GDO" secondAttribute="bottom" constant="20" id="MSu-kh-oBT"/>
+                            <constraint firstItem="PZ3-Dn-InO" firstAttribute="top" secondItem="mpC-fA-tlI" secondAttribute="top" constant="20" id="X95-VB-xbj"/>
+                            <constraint firstAttribute="trailing" secondItem="PZ3-Dn-InO" secondAttribute="trailing" constant="20" id="unZ-IV-pky"/>
+                            <constraint firstItem="xyd-lX-2OW" firstAttribute="top" secondItem="PZ3-Dn-InO" secondAttribute="bottom" id="yTK-af-qQq"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="3Dセキュア" id="geS-6K-CGg"/>
+                    <connections>
+                        <outlet property="resultLabel" destination="xyd-lX-2OW" id="KjC-Hp-flu"/>
+                        <outlet property="startButton" destination="bIy-sO-GDO" id="ZnM-71-8Jj"/>
+                        <outlet property="textField" destination="PZ3-Dn-InO" id="0Qc-1g-96E"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pF3-7n-ma3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="249" y="1685"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/example-objc/example-objc/CardFormViewScrollViewController.h
+++ b/example-objc/example-objc/CardFormViewScrollViewController.h
@@ -11,10 +11,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CardFormViewScrollViewController : UIViewController <PAYCardFormViewDelegate,
-                                                                UIPickerViewDelegate,
-                                                                UIPickerViewDataSource,
-                                                                UITextFieldDelegate>
+@interface CardFormViewScrollViewController
+    : UIViewController <PAYCardFormViewDelegate,
+                        PAYJPThreeDSecureProcessHandlerDelegate,
+                        UIPickerViewDelegate,
+                        UIPickerViewDataSource,
+                        UITextFieldDelegate>
 
 @end
 

--- a/example-objc/example-objc/ExampleHostViewController.m
+++ b/example-objc/example-objc/ExampleHostViewController.m
@@ -23,25 +23,27 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
   [tableView deselectRowAtIndexPath:indexPath animated:true];
 
-  if (indexPath.row == 0) {
-    [self pushCardFormWithViewType:CardFormViewTypeTableStyled];
-  }
+  if (indexPath.section == 0) {
+    if (indexPath.row == 0) {
+      [self pushCardFormWithViewType:CardFormViewTypeTableStyled];
+    }
 
-  if (indexPath.row == 1) {
-    // customize card form
-    //        UIColor *color = RGB(0, 122, 255);
-    //        PAYCardFormStyle *style = [[PAYCardFormStyle alloc] initWithLabelTextColor:color
-    //                                                                    inputTextColor:color
-    //                                                                    errorTextColor:nil
-    //                                                                         tintColor:color
-    //                                                         inputFieldBackgroundColor:nil
-    //                                                                 submitButtonColor:color
-    //                                                                    highlightColor:nil];
-    [self presentCardFormWithViewType:CardFormViewTypeLabelStyled];
-  }
+    if (indexPath.row == 1) {
+      // customize card form
+      //        UIColor *color = RGB(0, 122, 255);
+      //        PAYCardFormStyle *style = [[PAYCardFormStyle alloc] initWithLabelTextColor:color
+      //                                                                    inputTextColor:color
+      //                                                                    errorTextColor:nil
+      //                                                                         tintColor:color
+      //                                                         inputFieldBackgroundColor:nil
+      //                                                                 submitButtonColor:color
+      //                                                                    highlightColor:nil];
+      [self presentCardFormWithViewType:CardFormViewTypeLabelStyled];
+    }
 
-  if (indexPath.row == 2) {
-    [self pushCardFormWithViewType:CardFormViewTypeDisplayStyled];
+    if (indexPath.row == 2) {
+      [self pushCardFormWithViewType:CardFormViewTypeDisplayStyled];
+    }
   }
 }
 

--- a/example-objc/example-objc/ThreeDSecureExampleViewController.h
+++ b/example-objc/example-objc/ThreeDSecureExampleViewController.h
@@ -1,0 +1,16 @@
+//
+//  ThreeDSecureExampleViewController.h
+//  example-objc
+//
+
+#import <UIKit/UIKit.h>
+@import PAYJP;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ThreeDSecureExampleViewController
+    : UIViewController <PAYJPThreeDSecureProcessHandlerDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/example-objc/example-objc/ThreeDSecureExampleViewController.m
+++ b/example-objc/example-objc/ThreeDSecureExampleViewController.m
@@ -1,0 +1,60 @@
+//
+//  ThreeDSecureExampleViewController.m
+//  example-objc
+//
+
+#import "ThreeDSecureExampleViewController.h"
+#import "UIViewController+Alert.h"
+
+@interface ThreeDSecureExampleViewController ()
+
+@property(weak, nonatomic) IBOutlet UIButton *startButton;
+@property(weak, nonatomic) IBOutlet UITextField *textField;
+@property(weak, nonatomic) IBOutlet UILabel *resultLabel;
+@property(strong, nonatomic) NSString *pendingResourceId;
+
+@end
+
+@implementation ThreeDSecureExampleViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+}
+
+- (IBAction)startThreeDSecure:(id)sender {
+  if (self.textField.text.length == 0) {
+    self.resultLabel.text = @"";
+    self.resultLabel.hidden = YES;
+    return;
+  }
+
+  self.pendingResourceId = self.textField.text;
+  [[PAYJPThreeDSecureProcessHandler sharedHandler]
+      startThreeDSecureProcessWithViewController:self
+                                        delegate:self
+                                      resourceId:self.textField.text];
+}
+
+#pragma mark - PAYJPThreeDSecureProcessHandlerDelegate
+
+- (void)threeDSecureProcessHandlerDidFinish:(PAYJPThreeDSecureProcessHandler *)handler
+                                     status:(enum ThreeDSecureProcessStatus)status {
+  switch (status) {
+    case ThreeDSecureProcessStatusCompleted:
+      self.resultLabel.text =
+          @"3Dセキュア認証が終了しました。\nこの結果をサーバーサイドに伝え、完了処理や結果のハンド"
+          @"リングを行なってください。\n後続処理の実装方法に関してはドキュメントをご参照ください。";
+      self.resultLabel.textColor = UIColor.blackColor;
+      self.resultLabel.hidden = NO;
+      break;
+    case ThreeDSecureProcessStatusCanceled:
+      self.resultLabel.text = @"3Dセキュア認証がキャンセルされました。";
+      self.resultLabel.textColor = UIColor.redColor;
+      self.resultLabel.hidden = NO;
+      break;
+    default:
+      break;
+  }
+}
+
+@end

--- a/example-swift/example-swift-ui/AppDelegate.swift
+++ b/example-swift/example-swift-ui/AppDelegate.swift
@@ -28,7 +28,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ app: UIApplication,
                      open url: URL,
                      options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-
         return ThreeDSecureProcessHandler.shared.completeThreeDSecureProcess(url: url)
     }
 

--- a/example-swift/example-swift-ui/CardFormViewControllerExampleView.swift
+++ b/example-swift/example-swift-ui/CardFormViewControllerExampleView.swift
@@ -1,0 +1,64 @@
+//
+//  CardFormViewControllerExampleView.swift
+//  example-swift
+//
+
+import SwiftUI
+import PAYJP
+
+struct CardFormViewControllerExampleView: View {
+    @ObservedObject private var cardFormDelegate = CardFormDelegate()
+    var body: some View {
+        Button("Add Credit Card") {
+            self.cardFormDelegate.isPresented.toggle()
+        }
+        .sheet(isPresented: self.$cardFormDelegate.isPresented) {
+            CardFormViewControllerWrapper(delegate: self.cardFormDelegate)
+        }
+    }
+}
+
+// MARK: - CardFormViewControllerDelegate
+
+class CardFormDelegate: ObservableObject, CardFormViewControllerDelegate {
+    @Published var isPresented: Bool = false
+    
+    func cardFormViewController(_: CardFormViewController, didCompleteWith result: CardFormResult) {
+        switch result {
+        case .cancel:
+            print("CardFormResult.cancel")
+        case .success:
+            print("CardFormResult.success")
+            DispatchQueue.main.async { [weak self] in
+                self?.isPresented.toggle()
+            }
+        }
+    }
+    
+    func cardFormViewController(_: CardFormViewController,
+                                didProduced token: Token,
+                                completionHandler: @escaping (Error?) -> Void) {
+        print("token = \(String(describing: token.rawValue))")
+        // TODO: send token to server
+        completionHandler(nil)
+    }
+}
+
+// MARK: - CardFormViewControllerWrapper
+
+struct CardFormViewControllerWrapper: UIViewControllerRepresentable {
+    weak var delegate: CardFormViewControllerDelegate!
+    
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let cardFormVc =  CardFormViewController.createCardFormViewController(delegate: delegate,
+                                                                              viewType: .displayStyled)
+        let naviVc = UINavigationController(rootViewController: cardFormVc)
+        naviVc.presentationController?.delegate = cardFormVc
+        return naviVc
+    }
+    
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+    }
+    
+    typealias UIViewControllerType = UINavigationController
+}

--- a/example-swift/example-swift-ui/ContentView.swift
+++ b/example-swift/example-swift-ui/ContentView.swift
@@ -6,64 +6,27 @@
 //
 
 import SwiftUI
-import PAYJP
 
 struct ContentView: View {
-    @ObservedObject private weak var cardFormDelegate = CardFormDelegate()
     var body: some View {
-        Button("Add Credit Card") {
-            self.cardFormDelegate.isPresented.toggle()
-        }
-        .sheet(isPresented: self.$cardFormDelegate.isPresented) {
-            CardFormViewControllerWrapper(delegate: self.cardFormDelegate)
-        }
-    }
-}
-
-// MARK: - CardFormViewControllerDelegate
-
-class CardFormDelegate: ObservableObject, CardFormViewControllerDelegate {
-    @Published var isPresented: Bool = false
-
-    func cardFormViewController(_: CardFormViewController, didCompleteWith result: CardFormResult) {
-        switch result {
-        case .cancel:
-            print("CardFormResult.cancel")
-        case .success:
-            print("CardFormResult.success")
-            DispatchQueue.main.async { [weak self] in
-                self?.isPresented.toggle()
+        NavigationView {
+            List {
+                Section(header: Text("カードフォーム")) {
+                    NavigationLink(destination: CardFormViewControllerExampleView()) {
+                        Text("Card Form ViewController")
+                    }
+                }
+                Section(header: Text("支払い時の3Dセキュア、または顧客カードの3Dセキュア")) {
+                    NavigationLink(destination: ThreeDSecureProcessHandlerExampleView()) {
+                        Text("ThreeD Secure Process Handler")
+                    }
+                }
             }
+            .navigationBarTitle("Example")
         }
     }
-
-    func cardFormViewController(_: CardFormViewController,
-                                didProduced token: Token,
-                                completionHandler: @escaping (Error?) -> Void) {
-        print("token = \(token.rawValue)")
-        // TODO: send token to server
-        completionHandler(nil)
-    }
 }
 
-// MARK: - CardFormViewControllerWrapper
-
-struct CardFormViewControllerWrapper: UIViewControllerRepresentable {
-    weak var delegate: CardFormViewControllerDelegate
-
-    func makeUIViewController(context: Context) -> UINavigationController {
-        let cardFormVc =  CardFormViewController.createCardFormViewController(delegate: delegate,
-                                                                              viewType: .displayStyled)
-        let naviVc = UINavigationController(rootViewController: cardFormVc)
-        naviVc.presentationController?.delegate = cardFormVc
-        return naviVc
-    }
-
-    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
-    }
-
-    typealias UIViewControllerType = UINavigationController
-}
 
 // MARK: - Preview
 

--- a/example-swift/example-swift-ui/Info.plist
+++ b/example-swift/example-swift-ui/Info.plist
@@ -56,5 +56,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>exampleswift</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/example-swift/example-swift-ui/SceneDelegate.swift
+++ b/example-swift/example-swift-ui/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SwiftUI
+import PAYJP
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -28,7 +29,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             window.makeKeyAndVisible()
         }
     }
-
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let urlContext = URLContexts.first else { return }
+        let url = urlContext.url
+        ThreeDSecureProcessHandler.shared.completeThreeDSecureProcess(url: url)
+    }
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.

--- a/example-swift/example-swift-ui/ThreeDSecureProcessHandlerExampleView.swift
+++ b/example-swift/example-swift-ui/ThreeDSecureProcessHandlerExampleView.swift
@@ -1,0 +1,125 @@
+//
+//  ThreeDSecureProcessHandlerExampleView.swift
+//  example-swift
+//
+
+import SwiftUI
+import PAYJP
+
+class ThreeDSecureViewModel: ObservableObject, ThreeDSecureProcessHandlerDelegate {
+    @Published var pendingResourceId: String = ""
+    @Published var resultMessage: String = ""
+    @Published var showResult: Bool = false
+    @Published var isError: Bool = false
+    
+    func startThreeDSecureProcess() {
+        guard !pendingResourceId.isEmpty,
+              let rootViewController = UIApplication.shared.windows.first?.rootViewController else {
+            showResult = false
+            return
+        }
+        ThreeDSecureProcessHandler.shared.startThreeDSecureProcess(
+            viewController: rootViewController,
+            delegate: self,
+            resourceId: pendingResourceId
+        )
+    }
+    
+    // MARK: - ThreeDSecureProcessHandlerDelegate
+    func threeDSecureProcessHandlerDidFinish(_ handler: ThreeDSecureProcessHandler, status: ThreeDSecureProcessStatus) {
+        switch status {
+        case .completed:
+            DispatchQueue.main.async {
+                self.resultMessage = """
+                    3Dセキュア認証が終了しました。
+                    この結果をサーバーサイドに伝え、完了処理や結果のハンドリングを行なってください。
+                    後続処理の実装方法に関してはドキュメントをご参照ください。
+                    """
+                self.showResult = true
+                self.isError = false
+            }
+        case .canceled:
+            DispatchQueue.main.async {
+                self.resultMessage = "3Dセキュア認証がキャンセルされました。"
+                self.showResult = true
+                self.isError = true
+            }
+        }
+    }
+}
+
+struct ThreeDSecureProcessHandlerExampleView: View {
+    @ObservedObject private var viewModel = ThreeDSecureViewModel()
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                TextField("リソースIDを入力してください（ch_xxxx または tdsr_xx など）。",
+                          text: $viewModel.pendingResourceId
+                )
+                .padding()
+                .border(Color.gray, width: 1)
+                .padding(.horizontal)
+                
+                if viewModel.showResult {
+                    Text(viewModel.resultMessage)
+                        .foregroundColor(viewModel.isError ? .red : .black)
+                        .padding(.horizontal)
+                }
+                
+                Button(action: {
+                    // 3) Call the view model's start function
+                    viewModel.startThreeDSecureProcess()
+                }) {
+                    Text("3Dセキュア開始")
+                        .foregroundColor(.blue)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .padding(.horizontal)
+                
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("1.下記を参考に、先にサーバーサイドで支払い、または3Dセキュアリクエストを作成してください。")
+                    
+                    Text("支払い作成時の3Dセキュア：")
+                    if let url = URL(string: "https://pay.jp/docs/charge-tds") {
+                        Button(action: {
+                            UIApplication.shared.open(url)
+                        }) {
+                            Text("https://pay.jp/docs/charge-tds")
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    
+                    Text("顧客カードに対する3Dセキュア：")
+                    if let url = URL(string: "https://pay.jp/docs/customer-card-tds") {
+                        Button(action: {
+                            UIApplication.shared.open(url)
+                        }) {
+                            Text("https://pay.jp/docs/customer-card-tds")
+                                .foregroundColor(.blue)
+                        }
+                    }
+                }
+                .padding(.horizontal)
+                
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("2. 作成したリソースのIDを上記に入力して3Dセキュアを開始してください。")
+                    
+                    Text("3.立ち上がった画面が閉じ、認証が終了したら、ドキュメントを参考にサーバーサイドにて結果を確認してください。")
+                }
+                .padding(.horizontal)
+            }
+            .padding(.vertical)
+        }
+        .navigationBarTitle("3Dセキュア")
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+struct ThreeDSecureProcessHandlerExampleView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ThreeDSecureProcessHandlerExampleView()
+        }
+    }
+}

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0721B6CF2D4FBDDB0070C36F /* ThreeDSecureExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721B6CE2D4FBDCD0070C36F /* ThreeDSecureExampleViewController.swift */; };
+		07EFF5FF2D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; };
+		07EFF6002D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		07EFF6042D5CD0B400E66DAD /* ThreeDSecureProcessHandlerExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EFF6032D5CD08900E66DAD /* ThreeDSecureProcessHandlerExampleView.swift */; };
+		07EFF6062D5CE5FD00E66DAD /* CardFormViewControllerExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EFF6052D5CE5FD00E66DAD /* CardFormViewControllerExampleView.swift */; };
 		32167E0927B1C5F100E4BCD5 /* PAYJP.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; };
 		32167E0A27B1C5F100E4BCD5 /* PAYJP.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		32167E0C27B1C62900E4BCD5 /* PAYJP.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; };
@@ -52,6 +57,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				07EFF6002D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Embed Frameworks */,
 				32167E0D27B1C62900E4BCD5 /* PAYJP.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -60,6 +66,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0721B6CE2D4FBDCD0070C36F /* ThreeDSecureExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecureExampleViewController.swift; sourceTree = "<group>"; };
+		07EFF6032D5CD08900E66DAD /* ThreeDSecureProcessHandlerExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecureProcessHandlerExampleView.swift; sourceTree = "<group>"; };
+		07EFF6052D5CE5FD00E66DAD /* CardFormViewControllerExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormViewControllerExampleView.swift; sourceTree = "<group>"; };
 		32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PAYJP.xcframework; path = Carthage/Build/PAYJP.xcframework; sourceTree = "<group>"; };
 		3219F14B26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormViewWith3DSViewController.swift; sourceTree = "<group>"; };
 		3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PhoneNumberKit.xcframework; path = Carthage/Build/PhoneNumberKit.xcframework; sourceTree = "<group>"; };
@@ -92,6 +101,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07EFF5FF2D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Frameworks */,
 				32167E0C27B1C62900E4BCD5 /* PAYJP.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -114,6 +124,8 @@
 				32B471DF24C6AD180061579C /* AppDelegate.swift */,
 				32B471E124C6AD180061579C /* SceneDelegate.swift */,
 				32B471E324C6AD180061579C /* ContentView.swift */,
+				07EFF6052D5CE5FD00E66DAD /* CardFormViewControllerExampleView.swift */,
+				07EFF6032D5CD08900E66DAD /* ThreeDSecureProcessHandlerExampleView.swift */,
 				32B471E524C6AD1B0061579C /* Assets.xcassets */,
 				32B471EA24C6AD1B0061579C /* LaunchScreen.storyboard */,
 				32B471ED24C6AD1B0061579C /* Info.plist */,
@@ -157,6 +169,7 @@
 				ED50839223278BB800C64A7F /* CardFormViewExampleViewController.swift */,
 				ED5085BC232A0FE300C64A7F /* CardFormViewScrollViewController.swift */,
 				3219F14B26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift */,
+				0721B6CE2D4FBDCD0070C36F /* ThreeDSecureExampleViewController.swift */,
 				ED630C1623556BF4006C061E /* ColorTheme.swift */,
 				32CB11331FDA7E3D007AD8F5 /* Info.plist */,
 				32CB11301FDA7E3D007AD8F5 /* LaunchScreen.storyboard */,
@@ -327,8 +340,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07EFF6042D5CD0B400E66DAD /* ThreeDSecureProcessHandlerExampleView.swift in Sources */,
 				32B471E024C6AD180061579C /* AppDelegate.swift in Sources */,
 				32B471E224C6AD180061579C /* SceneDelegate.swift in Sources */,
+				07EFF6062D5CE5FD00E66DAD /* CardFormViewControllerExampleView.swift in Sources */,
 				32B471E424C6AD180061579C /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -340,6 +355,7 @@
 				3219F14C26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift in Sources */,
 				ED8BDA062383BA3B00680C05 /* ExampleHostViewController.swift in Sources */,
 				ED5085BD232A0FE300C64A7F /* CardFormViewScrollViewController.swift in Sources */,
+				0721B6CF2D4FBDDB0070C36F /* ThreeDSecureExampleViewController.swift in Sources */,
 				ED630C1723556BF4006C061E /* ColorTheme.swift in Sources */,
 				32CB112A1FDA7E3D007AD8F5 /* ViewController.swift in Sources */,
 				ED50839323278BB800C64A7F /* CardFormViewExampleViewController.swift in Sources */,

--- a/example-swift/example-swift/Base.lproj/Main.storyboard
+++ b/example-swift/example-swift/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SOm-Ex-W3S">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="SOm-Ex-W3S">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,10 +18,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
-                            <tableViewSection id="ErQ-9s-VQN">
+                            <tableViewSection headerTitle="トークン作成 組み込み方法ごと" id="ErQ-9s-VQN">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="IuP-2x-bTs" style="IBUITableViewCellStyleDefault" id="C6a-6n-Abo">
-                                        <rect key="frame" x="0.0" y="18" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="C6a-6n-Abo" id="86E-wP-Yp6">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
@@ -37,7 +38,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="NGo-cd-eBC" style="IBUITableViewCellStyleDefault" id="aSB-R8-ufb">
-                                        <rect key="frame" x="0.0" y="61.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="99" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aSB-R8-ufb" id="Y15-Id-mOw">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
@@ -54,7 +55,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="V4h-7V-K9g" style="IBUITableViewCellStyleDefault" id="lFf-uv-WIx">
-                                        <rect key="frame" x="0.0" y="105" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="142.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lFf-uv-WIx" id="lTn-G1-7GX">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
@@ -71,7 +72,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="vjX-Js-Ea8" style="IBUITableViewCellStyleDefault" id="gCJ-NH-9Bh">
-                                        <rect key="frame" x="0.0" y="148.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="186" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gCJ-NH-9Bh" id="kKe-b2-OWM">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
@@ -91,7 +92,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="1Vu-cK-rUK" style="IBUITableViewCellStyleDefault" id="gPV-c3-1yh">
-                                        <rect key="frame" x="0.0" y="192" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="229.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gPV-c3-1yh" id="FGo-H2-dKC">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
@@ -111,7 +112,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="qwQ-4M-drp" style="IBUITableViewCellStyleDefault" id="Akl-Ia-7TA">
-                                        <rect key="frame" x="0.0" y="235.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="273" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Akl-Ia-7TA" id="CO4-v4-oU9">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
@@ -131,7 +132,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="slR-R0-W8h" style="IBUITableViewCellStyleDefault" id="kGC-Pb-Wfc">
-                                        <rect key="frame" x="0.0" y="279" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="316.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kGC-Pb-Wfc" id="2G1-Vp-axv">
                                             <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
@@ -148,6 +149,30 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="VKh-Lw-K9Y" kind="show" id="I2p-4m-d3d"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="支払い時の3Dセキュア、または顧客カードの3Dセキュア" id="T8d-qv-BT2">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Enn-52-knW" style="IBUITableViewCellStyleDefault" id="cuJ-1w-rQt">
+                                        <rect key="frame" x="0.0" y="416" width="375" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cuJ-1w-rQt" id="VcG-f3-lFM">
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="ThreeDSecureProcessHandler startThreeDSecureProcess" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Enn-52-knW">
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="dJJ-tm-SId" kind="show" id="c2u-1F-kv0"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -239,10 +264,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ATz-im-tbk">
-                                        <rect key="frame" x="0.0" y="558.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="558.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ATz-im-tbk" id="9GV-kN-bag">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Select Color" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JOQ-DR-5qK">
@@ -259,14 +284,14 @@
                             <tableViewSection headerTitle="Last Token Id" id="dH9-G6-SJW">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Xcv-4P-L4F" style="IBUITableViewCellStyleDefault" id="kaL-va-TtG">
-                                        <rect key="frame" x="0.0" y="659" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="658" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kaL-va-TtG" id="gyG-8t-Kxy">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Xcv-4P-L4F">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -417,14 +442,14 @@
                             <tableViewSection headerTitle="Card Information" id="U5z-sT-dp5">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="YSU-01-62O">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YSU-01-62O" id="9Hb-xh-FlF">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G25-Sq-rcs">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="Lco-P3-ER8"/>
                                                     </constraints>
@@ -433,7 +458,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="4242424242424242" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Exr-dr-g0q">
-                                                    <rect key="frame" x="159" y="13" width="200" height="18.5"/>
+                                                    <rect key="frame" x="159" y="12.5" width="200" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="V7z-I7-D3p"/>
                                                     </constraints>
@@ -451,14 +476,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="r2y-8c-RfI">
-                                        <rect key="frame" x="0.0" y="100" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="99" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r2y-8c-RfI" id="JJJ-yi-n11">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="cvc" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Fy-FG-QbM">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="7hE-7Y-jyS"/>
                                                     </constraints>
@@ -467,7 +492,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="123" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Lz7-lQ-qoo">
-                                                    <rect key="frame" x="159" y="13" width="200" height="18.5"/>
+                                                    <rect key="frame" x="159" y="12.5" width="200" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="dEi-22-Dji"/>
                                                     </constraints>
@@ -485,14 +510,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Ikw-Q6-9pM">
-                                        <rect key="frame" x="0.0" y="144.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="142.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ikw-Q6-9pM" id="ol4-wz-d6f">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="month" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eEL-np-F3s">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="Fle-EG-TNb"/>
                                                     </constraints>
@@ -501,7 +526,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="12" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ySB-th-XuK">
-                                                    <rect key="frame" x="159" y="13" width="200" height="18.5"/>
+                                                    <rect key="frame" x="159" y="12.5" width="200" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="lGd-Dw-DD5"/>
                                                     </constraints>
@@ -519,14 +544,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="0zW-M9-7UY">
-                                        <rect key="frame" x="0.0" y="189" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="186" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0zW-M9-7UY" id="xk4-6g-NAk">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="year" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gIY-fC-7Is">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="dP2-1z-Hg5"/>
                                                     </constraints>
@@ -535,7 +560,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="2020" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="IQz-rn-7eQ">
-                                                    <rect key="frame" x="159" y="13" width="200" height="18.5"/>
+                                                    <rect key="frame" x="159" y="12.5" width="200" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="WdA-7E-p8e"/>
                                                     </constraints>
@@ -553,14 +578,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="LhL-9i-bzU">
-                                        <rect key="frame" x="0.0" y="233.5" width="375" height="44.5"/>
+                                        <rect key="frame" x="0.0" y="229.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LhL-9i-bzU" id="jcE-S7-KhN">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ipO-hJ-o18" userLabel="name">
-                                                    <rect key="frame" x="16" y="12" width="60" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="60" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="glh-cN-jCJ"/>
                                                     </constraints>
@@ -569,7 +594,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="TARO YAMADA" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0u3-7V-BFP">
-                                                    <rect key="frame" x="159" y="13" width="200" height="18.5"/>
+                                                    <rect key="frame" x="159" y="12.5" width="200" height="18.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="200" id="iSw-rg-HX6"/>
                                                     </constraints>
@@ -591,7 +616,7 @@
                             <tableViewSection id="a17-1D-eJy">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="TSV-5L-s1i" style="IBUITableViewCellStyleDefault" id="voI-jh-bsy">
-                                        <rect key="frame" x="0.0" y="314" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="309" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="voI-jh-bsy" id="PBQ-Ko-oP0">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -612,7 +637,7 @@
                             <tableViewSection headerTitle="last token id" footerTitle="Get token by token id. Fill it by creating token." id="QY1-9h-xy1">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="iSQ-BN-wpX" style="IBUITableViewCellStyleDefault" id="RTL-LH-MNd">
-                                        <rect key="frame" x="0.0" y="421" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="416" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RTL-LH-MNd" id="DIG-Xe-Fbj">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -729,10 +754,278 @@
             </objects>
             <point key="canvasLocation" x="-279" y="1911"/>
         </scene>
+        <!--3Dセキュア-->
+        <scene sceneID="gYo-mj-gek">
+            <objects>
+                <viewController id="dJJ-tm-SId" customClass="ThreeDSecureExampleViewController" customModule="example_swift" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="aDy-B9-LsF">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="リソースIDを入力してください（ch_xxxx または tdsr_xx など）。" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jkb-1F-oJI">
+                                <rect key="frame" x="20" y="84" width="335" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="Yv2-D5-vpP"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAd-vD-9SZ">
+                                <rect key="frame" x="20" y="128" width="335" height="90"/>
+                                <string key="text">3Dセキュア認証が終了しました。
+この結果をサーバーサイドに伝え、完了処理や結果のハンドリングを行なってください。
+後続処理の実装方法に関してはドキュメントをご参照ください。</string>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="752" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7EK-FB-HTx">
+                                <rect key="frame" x="115.5" y="242.5" width="144" height="34.5"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="3Dセキュア開始"/>
+                                <connections>
+                                    <action selector="startThreeDSecure:" destination="dJJ-tm-SId" eventType="touchUpInside" id="cHd-2w-mtr"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" usesAttributedText="YES" id="t9D-3c-gtD">
+                                <rect key="frame" x="0.0" y="297" width="375" height="370"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="1.">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="下記を参考に、先にサーバーサイドで支払い、または">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュアリクエストを作成してください。">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cgo
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="支払い作成時の">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュア：">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+IAo
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="https://pay.jp/docs/charge-tds">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <url key="NSLink" string="https://pay.jp/docs/charge-tds"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cg
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="顧客カードに対する">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュア：">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cg
+</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="https://pay.jp/docs/customer-card-tds">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <url key="NSLink" string="https://pay.jp/docs/customer-card-tds"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content">
+
+2. </string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="作成したリソースの">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="ID">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="を上記に入力して">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="3D">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="セキュアを開始してください。">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content">
+
+3.立ち上がった画面が閉じ、認証が終了したら</string>
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="、ドキュメントを参考にサーバーサイドにて結果を確認してください。">
+                                        <attributes>
+                                            <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <font key="NSFont" size="14" name="HiraginoSans-W3"/>
+                                            <font key="NSOriginalFont" size="12" name="Helvetica"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <dataDetectorType key="dataDetectorTypes" link="YES"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="QdF-iO-IRo"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="t9D-3c-gtD" firstAttribute="top" secondItem="7EK-FB-HTx" secondAttribute="bottom" constant="20" id="4aR-Ev-hPQ"/>
+                            <constraint firstItem="QdF-iO-IRo" firstAttribute="trailing" secondItem="hAd-vD-9SZ" secondAttribute="trailing" constant="20" id="67i-FP-cS4"/>
+                            <constraint firstItem="jkb-1F-oJI" firstAttribute="top" secondItem="QdF-iO-IRo" secondAttribute="top" constant="20" id="EVe-Ps-jEL"/>
+                            <constraint firstItem="jkb-1F-oJI" firstAttribute="leading" secondItem="aDy-B9-LsF" secondAttribute="leading" constant="20" id="JDx-Nm-esN"/>
+                            <constraint firstItem="7EK-FB-HTx" firstAttribute="centerX" secondItem="QdF-iO-IRo" secondAttribute="centerX" id="bcp-yV-x8f"/>
+                            <constraint firstAttribute="trailing" secondItem="jkb-1F-oJI" secondAttribute="trailing" constant="20" id="fgb-b2-OpL"/>
+                            <constraint firstItem="hAd-vD-9SZ" firstAttribute="top" secondItem="jkb-1F-oJI" secondAttribute="bottom" id="olG-GU-F3k"/>
+                            <constraint firstItem="hAd-vD-9SZ" firstAttribute="leading" secondItem="QdF-iO-IRo" secondAttribute="leading" constant="20" id="qCw-Hd-ylb"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="3Dセキュア" id="Ies-hn-j5y"/>
+                    <connections>
+                        <outlet property="resultLabel" destination="hAd-vD-9SZ" id="jgh-RH-WuN"/>
+                        <outlet property="startButton" destination="7EK-FB-HTx" id="3Vf-5r-JDL"/>
+                        <outlet property="textField" destination="jkb-1F-oJI" id="gT8-aL-vw2"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Tj7-1T-Lb1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-279.19999999999999" y="2616.3418290854574"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>

--- a/example-swift/example-swift/CardFormViewWith3DSViewController.swift
+++ b/example-swift/example-swift/CardFormViewWith3DSViewController.swift
@@ -67,8 +67,8 @@ class CardFormViewWith3DSViewController: UIViewController {
                 DispatchQueue.main.async {
                     if let tdsStatus = token.card.threeDSecureStatus, tdsStatus == .unverified {
                             self.pendingToken = token
-                            ThreeDSecureProcessHandler.shared.startThreeDSecureProcess(viewController: self, delegate: self, token: token)
-                        return
+                            ThreeDSecureProcessHandler.shared.startThreeDSecureProcess(viewController: self, delegate: self, resourceId: token.identifer)
+                            return
                     }
                     self.tokenIdLabel.text = token.identifer
                     self.showToken(token: token)

--- a/example-swift/example-swift/ExampleHostViewController.swift
+++ b/example-swift/example-swift/ExampleHostViewController.swift
@@ -14,15 +14,17 @@ class ExampleHostViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        switch indexPath.row {
-        case 0:
-            presentTdsAttributeOptions(viewType: .tableStyled, pushNavigation: true)
-        case 1:
-            presentTdsAttributeOptions(viewType: .labelStyled, pushNavigation: false)
-        case 2:
-            presentTdsAttributeOptions(viewType: .displayStyled, pushNavigation: true)
-        default:
-            break
+        if indexPath.section == 0 {
+            switch indexPath.row {
+            case 0:
+                presentTdsAttributeOptions(viewType: .tableStyled, pushNavigation: true)
+            case 1:
+                presentTdsAttributeOptions(viewType: .labelStyled, pushNavigation: false)
+            case 2:
+                presentTdsAttributeOptions(viewType: .displayStyled, pushNavigation: true)
+            default:
+                break
+            }
         }
     }
 

--- a/example-swift/example-swift/ThreeDSecureExampleViewController.swift
+++ b/example-swift/example-swift/ThreeDSecureExampleViewController.swift
@@ -1,0 +1,53 @@
+//
+//  ThreeDSecureExampleViewController.swift
+//  example-swift
+//
+
+import UIKit
+import PAYJP
+
+class ThreeDSecureExampleViewController: UIViewController {
+    @IBOutlet private var startButton: UIButton!
+    
+    @IBOutlet private var textField: UITextField!
+    
+    @IBOutlet private var resultLabel: UILabel!
+    
+    private var pendingResourceId: String?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    @IBAction private func startThreeDSecure(_ sender: Any) {
+        guard let resourceId = textField.text, !resourceId.isEmpty else {
+            self.resultLabel.text = ""
+            self.resultLabel.isHidden = true
+            return
+        }
+        
+        pendingResourceId = resourceId
+        ThreeDSecureProcessHandler.shared.startThreeDSecureProcess(viewController: self, delegate: self, resourceId: resourceId)
+    }
+}
+
+// MARK: - ThreeDSecureProcessHandlerDelegate
+
+extension ThreeDSecureExampleViewController: ThreeDSecureProcessHandlerDelegate {
+    func threeDSecureProcessHandlerDidFinish(_ handler: ThreeDSecureProcessHandler, status: ThreeDSecureProcessStatus) {
+        switch status {
+        case .completed:
+            DispatchQueue.main.async {
+                self.resultLabel.text = "3Dセキュア認証が終了しました。\nこの結果をサーバーサイドに伝え、完了処理や結果のハンドリングを行なってください。\n後続処理の実装方法に関してはドキュメントをご参照ください。"
+                self.resultLabel.textColor = .black
+                self.resultLabel.isHidden = false
+            }
+        case .canceled:
+            DispatchQueue.main.async {
+                self.resultLabel.text = "3Dセキュア認証がキャンセルされました。"
+                self.resultLabel.textColor = .red
+                self.resultLabel.isHidden = false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PAY.JP iOS SDKの変更点

既存のstartThreeDSecureProcessメソッドはトークン作成時の3Dセキュア認証のみを受け付けており、「支払い時」「顧客カードに対する3Dセキュア」に対応できていないため以下の新しいメソッドを追加します。

1. ThreeDSecureProcessHandlerTypeに新しいメソッドを追加:
```swift
func startThreeDSecureProcess(viewController: UIViewController,
                            delegate: ThreeDSecureProcessHandlerDelegate, 
                            resourceId: String)
```

2. 既存のトークンベースのメソッドを非推奨(deprecated)に設定:
```swift
    @available(*, deprecated, message: "Use startThreeDSecureProcess(viewController:delegate:resourceId:) instead.")
    func startThreeDSecureProcess(viewController: UIViewController,
                                  delegate: ThreeDSecureProcessHandlerDelegate,
                                  token: Token)
```

## サンプルアプリの変更点

### example-swift/example-objc 
- サンプルをトークン作成と3Dセキュアに分類
- ThreeDSecureProcessHandlerに新しいメソッドを使ったThreeDSecureExampleViewControllerを追加。

| 1 | 2 |
|--------|--------|
| ![Screenshot 2025-02-10 at 23 17 53](https://github.com/user-attachments/assets/b88d19c5-7881-4498-95f0-1b9380b5c82a) | ![Screenshot 2025-02-10 at 22 28 52](https://github.com/user-attachments/assets/ebc9e832-11ee-4e21-9ae9-cd6d92b12045) | 

### example-swiftui
- サンプルをカードフォームと3Dセキュアに分類
- ExampleViewControllerを追加。

| 1 | 2 |
|--------|--------|
|![Screenshot 2025-02-12 at 21 30 28](https://github.com/user-attachments/assets/b9be1f1f-d546-412c-acef-e88de566706c) | ![Screenshot 2025-02-12 at 21 18 29](https://github.com/user-attachments/assets/55f3f49e-af4b-4997-90f4-54c691c51e8e) |


