### PR TITLE
SFSafariViewController to ThreeDSecureWebViewController

### DIFF
--- a/PAYJP.xcodeproj/project.pbxproj
+++ b/PAYJP.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07492B2D2DABCE6F00BFD5C8 /* ThreeDSecureWebViewControllerDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07492B2C2DABCE6F00BFD5C8 /* ThreeDSecureWebViewControllerDriver.swift */; };
+		07492B2F2DABCF2700BFD5C8 /* ThreeDSecureWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07492B2E2DABCF2700BFD5C8 /* ThreeDSecureWebViewController.swift */; };
+		07EA3F2B2DB3F3A700D97904 /* ThreeDSecureWebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EA3F2A2DB3F3A700D97904 /* ThreeDSecureWebViewControllerTests.swift */; };
+		07EA3F2D2DB3F66300D97904 /* ThreeDSecureWebViewControllerDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EA3F2C2DB3F66300D97904 /* ThreeDSecureWebViewControllerDriverTests.swift */; };
 		07AEC1332D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AEC1322D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift */; };
 		07BC10742D4625CB00891977 /* PhoneNumberKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 328622622C6C42CB00DEA55B /* PhoneNumberKit.xcframework */; };
 		32167E0727B1C55800E4BCD5 /* OHHTTPStubs.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0627B1C55800E4BCD5 /* OHHTTPStubs.xcframework */; };
@@ -167,6 +171,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		07492B2C2DABCE6F00BFD5C8 /* ThreeDSecureWebViewControllerDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecureWebViewControllerDriver.swift; sourceTree = "<group>"; };
+		07492B2E2DABCF2700BFD5C8 /* ThreeDSecureWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecureWebViewController.swift; sourceTree = "<group>"; };
 		07AEC1322D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSecureURLConfigurationTests.swift; sourceTree = "<group>"; };
 		32167E0627B1C55800E4BCD5 /* OHHTTPStubs.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OHHTTPStubs.xcframework; path = Carthage/Build/OHHTTPStubs.xcframework; sourceTree = "<group>"; };
 		322BD1D5225C83CA00D83B5E /* JSONDecoder+PAYJP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+PAYJP.swift"; sourceTree = "<group>"; };
@@ -658,6 +664,8 @@
 				EDDB9370243AF0E400B5806B /* ThreeDSecureSFSafariViewControllerDriver.swift */,
 				ED00F8D0243353FC004DFE2C /* ThreeDSecureURLConfiguration.swift */,
 				ED3DB9DD243ABCEE0065FC33 /* ThreeDSecureWebDriver.swift */,
+				07492B2E2DABCF2700BFD5C8 /* ThreeDSecureWebViewController.swift */,
+				07492B2C2DABCE6F00BFD5C8 /* ThreeDSecureWebViewControllerDriver.swift */,
 			);
 			path = ThreeDSecure;
 			sourceTree = "<group>";
@@ -696,6 +704,8 @@
 				EDA0E418243739C00083A5E0 /* ThreeDSecureProcessHandlerTests.swift */,
 				ED3DB9E1243ACD2B0065FC33 /* ThreeDSecureSFSafariViewControllerDriverTests.swift */,
 				07AEC1322D492DD80054E345 /* ThreeDSecureURLConfigurationTests.swift */,
+				07EA3F2A2DB3F3A700D97904 /* ThreeDSecureWebViewControllerTests.swift */,
+				07EA3F2C2DB3F66300D97904 /* ThreeDSecureWebViewControllerDriverTests.swift */,
 				ED3DB9DF243ACCBE0065FC33 /* Mock.swift */,
 			);
 			path = ThreeDSecure;
@@ -863,7 +873,9 @@
 			files = (
 				32A8E4CC23B4616A001D1C38 /* JSONDecodable.swift in Sources */,
 				EDCF723322F9490400272C10 /* String+PAYJP.swift in Sources */,
+				07492B2F2DABCF2700BFD5C8 /* ThreeDSecureWebViewController.swift in Sources */,
 				ED00F8D1243353FD004DFE2C /* ThreeDSecureProcessHandler.swift in Sources */,
+				07492B2D2DABCE6F00BFD5C8 /* ThreeDSecureWebViewControllerDriver.swift in Sources */,
 				EDCF723222F948F500272C10 /* CardNumber.swift in Sources */,
 				ED3DB9DE243ABCEE0065FC33 /* ThreeDSecureWebDriver.swift in Sources */,
 				EDCF723122F948ED00272C10 /* FormError.swift in Sources */,
@@ -980,6 +992,7 @@
 				32585BB22CAC5237003F920B /* CardHolderValidatorTests.swift in Sources */,
 				ED3FEF7522F13F6000FA73BF /* String+PAYJPTests.swift in Sources */,
 				BE6C231020B566AE00C4FE1E /* APIErrorNSErrorTests.swift in Sources */,
+07EA3F2B2DB3F3A700D97904 /* ThreeDSecureWebViewControllerTests.swift in Sources */,
 				ED016AAF234ACE030049E6CE /* NSErrorConverterTests.swift in Sources */,
 				C68681F81E1E22DB001D7F75 /* CardFromTokenTests.swift in Sources */,
 				BE21785B22E99BB30098128D /* CreateTokenForApplePayRequestTests.swift in Sources */,
@@ -987,6 +1000,7 @@
 				BE734B8A22DD7DE2008679EC /* ExpirationFormatterTests.swift in Sources */,
 				BE21785722E995C40098128D /* CreateTokenRequestTests.swift in Sources */,
 				BE21786322E9B9A90098128D /* GetAcceptedBrandsTests.swift in Sources */,
+07EA3F2D2DB3F66300D97904 /* ThreeDSecureWebViewControllerDriverTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Resources/Resource.bundle/en.lproj/Localizable.strings
+++ b/Sources/Resources/Resource.bundle/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 // common
 "payjp_common_ok" = "OK";
 "payjp_common_settings" = "Settings";
+"payjp_common_close" = "Close";
 
 // card form
 "payjp_card_form_number_label" = "Card number";

--- a/Sources/Resources/Resource.bundle/en.lproj/tdserror.html
+++ b/Sources/Resources/Resource.bundle/en.lproj/tdserror.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>PAY.JP 3Dセキュア</title>
+                <style>
+                    * {
+                        box-sizing: border-box;
+                        margin:0;
+                        padding:0;
+                    }
+                    html {
+                        height: 100%;
+                    }
+                    body{
+                        font-family: "游ゴシック体", YuGothic, "游ゴシック", "Yu Gothic", sans-serif;
+                        min-height: 100vh;
+                    }
+                    .wrap{
+                        width: 100%;
+                        min-height: 100vh;
+                        position: relative;
+                    }
+                    .content {
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        flex-direction: column;
+                        gap: 24px;
+                        padding: 30px;
+                        height: 100vh;
+                    }
+                    .content .caption-box{
+                        width: 100%;
+                        max-width: 320px;
+                    }
+                    .content .caption{
+                        font-size: 12px;
+                        text-align: left;
+                    }
+                    .content .title{
+                        text-align: center;
+                        font-weight: bold;
+                        font-size:18px;
+                    }
+                    .content .description {
+                        font-size: 16px;
+                        text-align: center;
+                    }
+                </style>
+            </head>
+    <body>
+        <div class="wrap">
+            <section class="content">
+                <svg fill="none" height="33" viewBox="0 0 32 33" width="32" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16.5" fill="#fff" r="15" stroke="#ba0022" stroke-width="2"/><path d="m16 19.9617c-.8648 0-1.5375-.6726-1.5375-1.5375v-12.25193c0-.86485.6727-1.58555 1.5375-1.58555.8168 0 1.5375.7207 1.5375 1.58555v12.30003c0 .8168-.7207 1.4894-1.5375 1.4894zm0 2.3063c1.057 0 1.9219.9129 1.9219 1.9218 0 1.0571-.8649 1.9219-1.9219 1.9219-1.1051 0-1.9219-.8168-1.9219-1.9219 0-1.057.8168-1.9218 1.9219-1.9218z" fill="#ba0022"/></svg>
+                <p class="title">Authentication Error</p>
+                
+                <div class="caption-box">
+                    <p class="description">
+                    An error occurred within the app during authentication.<br>
+                    Please return to the previous page and try again from the beginning.
+                    </p>
+                </div>
+                
+                <div class="caption-box">
+                    <p class="caption">
+                    If the problem persists, please contact the service you are using with the error message below.
+                    <br><br>{{errorMessage}}
+                    </p>
+                </div>
+            </section>
+        </div>
+    </body>
+</html>

--- a/Sources/Resources/Resource.bundle/ja.lproj/Localizable.strings
+++ b/Sources/Resources/Resource.bundle/ja.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 // common
 "payjp_common_ok" = "OK";
 "payjp_common_settings" = "設定";
+"payjp_common_close" = "閉じる";
 
 // card form
 "payjp_card_form_number_label" = "カード番号";

--- a/Sources/Resources/Resource.bundle/ja.lproj/tdserror.html
+++ b/Sources/Resources/Resource.bundle/ja.lproj/tdserror.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>PAY.JP 3Dセキュア</title>
+                <style>
+                    * {
+                        box-sizing: border-box;
+                        margin:0;
+                        padding:0;
+                    }
+                    html {
+                        height: 100%;
+                    }
+                    body{
+                        font-family: "游ゴシック体", YuGothic, "游ゴシック", "Yu Gothic", sans-serif;
+                        min-height: 100vh;
+                    }
+                    .wrap{
+                        width: 100%;
+                        min-height: 100vh;
+                        position: relative;
+                    }
+                    .content {
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        flex-direction: column;
+                        gap: 24px;
+                        padding: 30px;
+                        height: 100vh;
+                    }
+                    .content .caption-box{
+                        width: 100%;
+                        max-width: 320px;
+                    }
+                    .content .caption{
+                        font-size: 12px;
+                        text-align: left;
+                    }
+                    .content .title{
+                        text-align: center;
+                        font-weight: bold;
+                        font-size:18px;
+                    }
+                    .content .description {
+                        font-size: 16px;
+                        text-align: center;
+                    }
+                </style>
+            </head>
+    <body>
+        <div class="wrap">
+            <section class="content">
+                <svg fill="none" height="33" viewBox="0 0 32 33" width="32" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16.5" fill="#fff" r="15" stroke="#ba0022" stroke-width="2"/><path d="m16 19.9617c-.8648 0-1.5375-.6726-1.5375-1.5375v-12.25193c0-.86485.6727-1.58555 1.5375-1.58555.8168 0 1.5375.7207 1.5375 1.58555v12.30003c0 .8168-.7207 1.4894-1.5375 1.4894zm0 2.3063c1.057 0 1.9219.9129 1.9219 1.9218 0 1.0571-.8649 1.9219-1.9219 1.9219-1.1051 0-1.9219-.8168-1.9219-1.9219 0-1.057.8168-1.9218 1.9219-1.9218z" fill="#ba0022"/></svg>
+                <p class="title">認証エラー</p>
+                
+                <div class="caption-box">
+                    <p class="description">
+                    認証中にアプリ内でエラーが発生しました。<br>
+                    元のページに戻り、最初からやり直してください。
+                    </p>
+                </div>
+                
+                <div class="caption-box">
+                    <p class="caption">
+                    問題が解決しない場合は、下記のエラーメッセージを添えてご利用のサービスにお問い合わせください。
+                    <br><br>{{errorMessage}}
+                    </p>
+                </div>
+            </section>
+        </div>
+    </body>
+</html>

--- a/Sources/ThreeDSecure/ThreeDSecureWebViewController.swift
+++ b/Sources/ThreeDSecure/ThreeDSecureWebViewController.swift
@@ -1,0 +1,203 @@
+import UIKit
+import WebKit
+
+protocol ThreeDSecureWebViewControllerDelegate: AnyObject {
+    func webViewControllerDidFinish(_ controller: ThreeDSecureWebViewController, completed: Bool)
+}
+
+@objcMembers open class ThreeDSecureWebViewController: UIViewController {
+
+    // MARK: - Properties
+
+    private static let timeoutInterval: TimeInterval = 10.0
+
+    private let webView: WKWebView
+    private let navigationBar = UINavigationBar()
+    private let initialURL: URL
+    weak var delegate: ThreeDSecureWebViewControllerDelegate?
+
+    // MARK: - Initialization
+
+    /// 指定されたURLおよびオプションで許可ドメインを指定してWebViewControllerを初期化する。
+    ///
+    /// - Parameters:
+    ///   - url: WebViewで最初に読み込むURL。
+    @objc public init(
+        url: URL
+    ) {
+        self.initialURL = url
+
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .default()
+        let version = Bundle.payjpBundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        configuration.applicationNameForUserAgent = "PAY.JP iOS WKWebView/\(version)"
+        if #available(iOS 14.0, *) {
+            let preferences = WKWebpagePreferences()
+            preferences.allowsContentJavaScript = true
+            configuration.defaultWebpagePreferences = preferences
+        } else {
+            configuration.preferences.javaScriptEnabled = true
+        }
+        self.webView = WKWebView(frame: .zero, configuration: configuration)
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required public init?(coder: NSCoder) {
+        fatalError(
+            "init(coder:) has not been implemented. Use init(url: URL) instead."
+        )
+    }
+
+    // MARK: - Lifecycle Methods
+
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupWebView()
+        setupNavigationBar()
+        layoutUI()
+
+        loadInitialURL()
+    }
+
+    override open func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        if isMovingFromParent || isBeingDismissed {
+            webView.stopLoading()
+            webView.navigationDelegate = nil
+        }
+    }
+
+    // MARK: - Setup
+
+    private func setupWebView() {
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        view.addSubview(webView)
+    }
+
+    private func setupNavigationBar() {
+        let navItem = UINavigationItem()
+        if #available(iOS 13.0, *) {
+            navigationBar.barTintColor = UIColor.systemBackground
+        }
+        navigationBar.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(navigationBar)
+
+        let closeButton = UIButton(type: .system)
+        closeButton.setTitle("payjp_common_close".localized, for: .normal)
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        navItem.leftBarButtonItem = UIBarButtonItem(customView: closeButton)
+        navigationBar.items = [navItem]
+    }
+
+    private func layoutUI() {
+        NSLayoutConstraint.activate([
+            navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+
+            webView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+
+    // MARK: - Actions
+
+    private func loadInitialURL() {
+        let request = URLRequest(url: initialURL, cachePolicy: .useProtocolCachePolicy, timeoutInterval: Self.timeoutInterval)
+        webView.load(request)
+    }
+
+    @objc private func closeButtonTapped() {
+        delegate?.webViewControllerDidFinish(self, completed: false)
+    }
+}
+
+// MARK: - WKNavigationDelegate
+
+extension ThreeDSecureWebViewController: WKNavigationDelegate {
+
+    public func webView(
+        _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+        print("WebView navigation action: \(url)")
+
+        // 設定されたリダイレクトURLに前方一致するかチェック
+        if let redirectUrl = PAYJPSDK.threeDSecureURLConfiguration?.redirectURL,
+           url.absoluteString.starts(with: redirectUrl.absoluteString) {
+            print("Detected redirect URL, attempting to open: \(url)")
+            UIApplication.shared.open(url, options: [:]) { [weak self] success in
+                guard let self = self else { return }
+                if success {
+                    print("Successfully opened redirect URL: \(url)")
+                    self.delegate?.webViewControllerDidFinish(self, completed: true)
+                }
+            }
+            decisionHandler(.cancel)
+            return
+        }
+
+        // Resource.bundle配下のfileスキームのみ許可
+        if let scheme = url.scheme?.lowercased(), scheme == "file" {
+            let resourceBundlePath = Bundle.resourceBundle.bundlePath
+            if url.path.hasPrefix(resourceBundlePath + "/") {
+                decisionHandler(.allow)
+                return
+            } else {
+                decisionHandler(.cancel)
+                return
+            }
+        }
+
+        decisionHandler(.allow)
+    }
+
+    public func webView(
+        _ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!
+    ) {
+        print("WebView started loading: \(webView.url?.absoluteString ?? "")")
+    }
+
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        print("WebView finished loading: \(webView.url?.absoluteString ?? "")")
+    }
+
+    public func webView(
+        _ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error
+    ) {
+        print("WebView failed navigation with error: \(error)")
+        loadErrorHTML(in: webView, error: error)
+    }
+
+    public func webView(
+        _ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        print("WebView failed provisional navigation with error: \(error)")
+        loadErrorHTML(in: webView, error: error)
+    }
+
+    private func loadErrorHTML(in webView: WKWebView, error: Error? = nil) {
+        let resourceBundle = Bundle.resourceBundle
+        guard let htmlURL = resourceBundle.url(forResource: "tdserror", withExtension: "html"),
+              let htmlData = try? Data(contentsOf: htmlURL),
+              var htmlString = String(data: htmlData, encoding: .utf8) else {
+            return
+        }
+        let errorMessage = error?.localizedDescription ?? ""
+        htmlString = htmlString.replacingOccurrences(of: "{{errorMessage}}", with: errorMessage)
+        webView.loadHTMLString(htmlString, baseURL: htmlURL.deletingLastPathComponent())
+    }
+}

--- a/Sources/ThreeDSecure/ThreeDSecureWebViewControllerDriver.swift
+++ b/Sources/ThreeDSecure/ThreeDSecureWebViewControllerDriver.swift
@@ -1,0 +1,62 @@
+import Foundation
+import UIKit
+
+public class ThreeDSecureWebViewControllerDriver: NSObject, ThreeDSecureWebDriver {
+
+    public static let shared = ThreeDSecureWebViewControllerDriver()
+
+    private weak var webDriverDelegate: ThreeDSecureWebDriverDelegate?
+    private weak var webViewController: ThreeDSecureWebViewController?
+
+    public func openWebBrowser(host: UIViewController, url: URL, delegate: ThreeDSecureWebDriverDelegate) {
+        closeWebBrowserInternal {}
+
+        let webVC = ThreeDSecureWebViewController(url: url)
+        webVC.delegate = self
+        webVC.modalPresentationStyle = .fullScreen
+        self.webDriverDelegate = delegate
+        self.webViewController = webVC
+
+        host.present(webVC, animated: true, completion: nil)
+    }
+
+    public func closeWebBrowser(host: UIViewController?, completion: (() -> Void)?) -> Bool {
+        if host == nil || host === self.webViewController {
+            return closeWebBrowserInternal(completion: completion)
+        }
+        completion?()
+        return false
+    }
+
+    @discardableResult
+    private func closeWebBrowserInternal(completion: (() -> Void)? = nil) -> Bool {
+        guard let webVC = self.webViewController else {
+            completion?()
+            return false
+        }
+
+        guard webVC.presentingViewController != nil || webVC.navigationController?.isBeingDismissed == false else {
+            completion?()
+            return false
+        }
+
+        webVC.dismiss(animated: true) { [weak self] in
+            self?.webViewController = nil
+            completion?()
+        }
+        return true
+    }
+}
+
+// MARK: - ThreeDSecureWebViewControllerDelegate
+extension ThreeDSecureWebViewControllerDriver: ThreeDSecureWebViewControllerDelegate {
+
+    func webViewControllerDidFinish(_ controller: ThreeDSecureWebViewController, completed: Bool) {
+        closeWebBrowserInternal { [weak self] in
+            guard let self = self else { return }
+            if !completed {
+                self.webDriverDelegate?.webBrowseDidFinish(self)
+            }
+        }
+    }
+}

--- a/Tests/ThreeDSecure/ThreeDSecureWebViewControllerDriverTests.swift
+++ b/Tests/ThreeDSecure/ThreeDSecureWebViewControllerDriverTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import PAYJP
+
+final class ThreeDSecureWebViewControllerDriverTests: XCTestCase {
+    class DummyHostViewController: UIViewController {
+        var presentedVC: UIViewController?
+        override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+            presentedVC = viewControllerToPresent
+            completion?()
+        }
+    }
+
+    class DummyDelegate: ThreeDSecureWebDriverDelegate {
+        var didFinishCalled = false
+        func webBrowseDidFinish(_ driver: ThreeDSecureWebDriver) {
+            didFinishCalled = true
+        }
+    }
+
+    func testOpenWebBrowser_presentsWebViewController() {
+        let driver = ThreeDSecureWebViewControllerDriver()
+        let host = DummyHostViewController()
+        let delegate = DummyDelegate()
+        let url = URL(string: "https://example.com")!
+
+        driver.openWebBrowser(host: host, url: url, delegate: delegate)
+        XCTAssertTrue(host.presentedVC is ThreeDSecureWebViewController)
+    }
+
+    func testCloseWebBrowser_dismissesWebViewController() {
+        let driver = ThreeDSecureWebViewControllerDriver()
+        let host = DummyHostViewController()
+        let delegate = DummyDelegate()
+        let url = URL(string: "https://example.com")!
+        driver.openWebBrowser(host: host, url: url, delegate: delegate)
+        let result = driver.closeWebBrowser(host: nil, completion: nil)
+        XCTAssertTrue(result)
+    }
+
+    func testWebViewControllerDidFinish_callsDelegate() {
+        let driver = ThreeDSecureWebViewControllerDriver()
+        let host = DummyHostViewController()
+        let delegate = DummyDelegate()
+        let url = URL(string: "https://example.com")!
+        driver.openWebBrowser(host: host, url: url, delegate: delegate)
+        if let webVC = host.presentedVC as? ThreeDSecureWebViewController {
+            (driver as? ThreeDSecureWebViewControllerDriver)?.webViewControllerDidFinish(webVC, completed: false)
+            XCTAssertTrue(delegate.didFinishCalled)
+        } else {
+            XCTFail("WebViewController was not presented")
+        }
+    }
+}

--- a/Tests/ThreeDSecure/ThreeDSecureWebViewControllerTests.swift
+++ b/Tests/ThreeDSecure/ThreeDSecureWebViewControllerTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+import WebKit
+@testable import PAYJP
+
+final class ThreeDSecureWebViewControllerTests: XCTestCase {
+    func testUserAgentIsSetCorrectly() {
+        let version = Bundle.payjpBundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        let url = URL(string: "https://example.com")!
+        let vc = ThreeDSecureWebViewController(url: url)
+        let exp = expectation(description: "Retrieve UserAgent")
+
+        _ = vc.view
+
+        let webViewMirror = Mirror(reflecting: vc)
+        guard let webView = webViewMirror.children.first(where: { $0.label == "webView" })?.value as? WKWebView else {
+            XCTFail("Failed to retrieve webView")
+            return
+        }
+        webView.evaluateJavaScript("navigator.userAgent") { result, error in
+            guard let userAgent = result as? String else {
+                XCTFail("Failed to retrieve UserAgent: \(error?.localizedDescription ?? "")")
+                exp.fulfill()
+                return
+            }
+            XCTAssertTrue(userAgent.contains("PAY.JP iOS WKWebView/\(version)"), "Expected value is not included in UserAgent: \(userAgent)")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+    }
+
+    func testErrorIsDisplayedInWebView() {
+        let url = URL(string: "http://invalid.invalid-domain-for-test-404.localhost/")!
+        let vc = ThreeDSecureWebViewController(url: url)
+        let exp = expectation(description: "Display error HTML")
+
+        _ = vc.view
+
+        let webViewMirror = Mirror(reflecting: vc)
+        guard let webView = webViewMirror.children.first(where: { $0.label == "webView" })?.value as? WKWebView else {
+            XCTFail("Failed to retrieve webView")
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            webView.evaluateJavaScript("document.body.innerHTML") { result, error in
+                guard let html = result as? String else {
+                    XCTFail("Failed to retrieve HTML: \(error?.localizedDescription ?? "")")
+                    exp.fulfill()
+                    return
+                }
+                XCTAssertTrue(html.contains("A server with the specified hostname could not be found."), "Error content is not included in the HTML: \(html)")
+                exp.fulfill()
+            }
+        }
+        wait(for: [exp], timeout: 10.0)
+    }
+}


### PR DESCRIPTION
3Dセキュア認証のリダイレクトフローを行うウェブブラウザをSFSafariViewControllerから内部のThreeDSecureWebViewControllerに変更します。

- Sources/ThreeDSecure/ThreeDSecureProcessHandler.swift: 呼び出し元の変更
- Sources/ThreeDSecure/ThreeDSecureWebViewControllerDriver.swift: Driverクラスも合わせて追加