### PR TITLE
feat(example): PAY.JP Checkout V2 app and server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ firebase-debug.log
 docs/docsets/*.tgz
 
 Brewfile.lock.json
+
+# Checkout example
+example-checkout-v2/server/.env
+example-checkout-v2/server/node_modules/

--- a/example-checkout-v2/ios/PayJPCheckoutExample.xcodeproj/project.pbxproj
+++ b/example-checkout-v2/ios/PayJPCheckoutExample.xcodeproj/project.pbxproj
@@ -1,0 +1,474 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		071057F42F1FA00000579957 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 071057D72F1E850600579957 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 071057DE2F1E850600579957;
+			remoteInfo = PayJPCheckoutExample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		071057DF2F1E850600579957 /* PayJPCheckoutExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PayJPCheckoutExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		071057F02F1FA00000579957 /* PayJPCheckoutExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PayJPCheckoutExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		071057F82F24857F00579957 /* Exceptions for "PayJPCheckoutExample" folder in "PayJPCheckoutExample" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 071057DE2F1E850600579957 /* PayJPCheckoutExample */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		071057E12F1E850600579957 /* PayJPCheckoutExample */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				071057F82F24857F00579957 /* Exceptions for "PayJPCheckoutExample" folder in "PayJPCheckoutExample" target */,
+			);
+			path = PayJPCheckoutExample;
+			sourceTree = "<group>";
+		};
+		071057F12F1FA00000579957 /* PayJPCheckoutExampleTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PayJPCheckoutExampleTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		071057DC2F1E850600579957 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		071057ED2F1FA00000579957 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		071057D62F1E850600579957 = {
+			isa = PBXGroup;
+			children = (
+				071057E12F1E850600579957 /* PayJPCheckoutExample */,
+				071057F12F1FA00000579957 /* PayJPCheckoutExampleTests */,
+				071057E02F1E850600579957 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		071057E02F1E850600579957 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				071057DF2F1E850600579957 /* PayJPCheckoutExample.app */,
+				071057F02F1FA00000579957 /* PayJPCheckoutExampleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		071057DE2F1E850600579957 /* PayJPCheckoutExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 071057EA2F1E850700579957 /* Build configuration list for PBXNativeTarget "PayJPCheckoutExample" */;
+			buildPhases = (
+				071057DB2F1E850600579957 /* Sources */,
+				071057DC2F1E850600579957 /* Frameworks */,
+				071057DD2F1E850600579957 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				071057E12F1E850600579957 /* PayJPCheckoutExample */,
+			);
+			name = PayJPCheckoutExample;
+			packageProductDependencies = (
+			);
+			productName = PayJPCheckoutExample;
+			productReference = 071057DF2F1E850600579957 /* PayJPCheckoutExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		071057EF2F1FA00000579957 /* PayJPCheckoutExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 071057F82F1FA00000579957 /* Build configuration list for PBXNativeTarget "PayJPCheckoutExampleTests" */;
+			buildPhases = (
+				071057EC2F1FA00000579957 /* Sources */,
+				071057ED2F1FA00000579957 /* Frameworks */,
+				071057EE2F1FA00000579957 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				071057F52F1FA00000579957 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				071057F12F1FA00000579957 /* PayJPCheckoutExampleTests */,
+			);
+			name = PayJPCheckoutExampleTests;
+			packageProductDependencies = (
+			);
+			productName = PayJPCheckoutExampleTests;
+			productReference = 071057F02F1FA00000579957 /* PayJPCheckoutExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		071057D72F1E850600579957 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2610;
+				LastUpgradeCheck = 2610;
+				TargetAttributes = {
+					071057DE2F1E850600579957 = {
+						CreatedOnToolsVersion = 26.1.1;
+					};
+					071057EF2F1FA00000579957 = {
+						CreatedOnToolsVersion = 26.1.1;
+						TestTargetID = 071057DE2F1E850600579957;
+					};
+				};
+			};
+			buildConfigurationList = 071057DA2F1E850600579957 /* Build configuration list for PBXProject "PayJPCheckoutExample" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 071057D62F1E850600579957;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 071057E02F1E850600579957 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				071057DE2F1E850600579957 /* PayJPCheckoutExample */,
+				071057EF2F1FA00000579957 /* PayJPCheckoutExampleTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		071057DD2F1E850600579957 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		071057EE2F1FA00000579957 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		071057DB2F1E850600579957 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		071057EC2F1FA00000579957 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		071057F52F1FA00000579957 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 071057DE2F1E850600579957 /* PayJPCheckoutExample */;
+			targetProxy = 071057F42F1FA00000579957 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		071057E82F1E850700579957 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		071057E92F1E850700579957 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		071057EB2F1E850700579957 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PayJPCheckoutExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-v2-checkout.PayJPCheckoutExample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		071057EC2F1E850700579957 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PayJPCheckoutExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-v2-checkout.PayJPCheckoutExample";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		071057F62F1FA00000579957 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-v2-checkout.PayJPCheckoutExampleTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PayJPCheckoutExample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PayJPCheckoutExample";
+			};
+			name = Debug;
+		};
+		071057F72F1FA00000579957 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-v2-checkout.PayJPCheckoutExampleTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PayJPCheckoutExample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PayJPCheckoutExample";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		071057DA2F1E850600579957 /* Build configuration list for PBXProject "PayJPCheckoutExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				071057E82F1E850700579957 /* Debug */,
+				071057E92F1E850700579957 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		071057EA2F1E850700579957 /* Build configuration list for PBXNativeTarget "PayJPCheckoutExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				071057EB2F1E850700579957 /* Debug */,
+				071057EC2F1E850700579957 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		071057F82F1FA00000579957 /* Build configuration list for PBXNativeTarget "PayJPCheckoutExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				071057F62F1FA00000579957 /* Debug */,
+				071057F72F1FA00000579957 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 071057D72F1E850600579957 /* Project object */;
+}

--- a/example-checkout-v2/ios/PayJPCheckoutExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example-checkout-v2/ios/PayJPCheckoutExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/example-checkout-v2/ios/PayJPCheckoutExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/example-checkout-v2/ios/PayJPCheckoutExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example-checkout-v2/ios/PayJPCheckoutExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/example-checkout-v2/ios/PayJPCheckoutExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example-checkout-v2/ios/PayJPCheckoutExample/Assets.xcassets/Contents.json
+++ b/example-checkout-v2/ios/PayJPCheckoutExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/example-checkout-v2/ios/PayJPCheckoutExample/ContentView.swift
+++ b/example-checkout-v2/ios/PayJPCheckoutExample/ContentView.swift
@@ -1,0 +1,332 @@
+//
+//  ContentView.swift
+//  PayJPCheckoutExample
+//
+//  2026/01/19.
+//
+
+import SwiftUI
+import SafariServices
+import Combine
+
+// MARK: - Models
+
+struct CheckoutSessionResponse: Decodable {
+    let id: String
+    let url: String
+    let status: String
+}
+
+struct SampleProduct: Identifiable, Decodable {
+    let id: String
+    let name: String
+    let amount: Int
+}
+
+struct ProductsResponse: Decodable {
+    let products: [SampleProduct]
+}
+
+// MARK: - ViewModel
+
+class CheckoutViewModel: ObservableObject {
+    @Published var backendURL: String = "http://localhost:3000"
+    @Published var selectedProduct: SampleProduct?
+    @Published var isLoading: Bool = false
+    @Published var checkoutURL: URL?
+    @Published var resultMessage: String = ""
+    @Published var showResult: Bool = false
+    @Published var isError: Bool = false
+    @Published var products: [SampleProduct] = []
+    @Published var isLoadingProducts: Bool = false
+    @Published var productsErrorMessage: String = ""
+
+    private var notificationObserver: Any?
+
+    init() {
+        notificationObserver = NotificationCenter.default.addObserver(
+            forName: .checkoutRedirect,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            if let url = notification.userInfo?["url"] as? URL {
+                self?.handleRedirectURL(url)
+            }
+        }
+    }
+
+    deinit {
+        if let observer = notificationObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    func fetchProductsIfNeeded() {
+        if products.isEmpty && !isLoadingProducts {
+            fetchProducts()
+        }
+    }
+
+    func fetchProducts() {
+        guard !backendURL.isEmpty else {
+            productsErrorMessage = "サーバーURLを入力してください"
+            return
+        }
+
+        guard let serverURL = URL(string: backendURL) else {
+            productsErrorMessage = "無効なURLです"
+            return
+        }
+
+        isLoadingProducts = true
+        productsErrorMessage = ""
+        selectedProduct = nil
+
+        let endpoint = serverURL.appendingPathComponent("products")
+        URLSession.shared.dataTask(with: endpoint) { [weak self] data, _, error in
+            DispatchQueue.main.async {
+                self?.isLoadingProducts = false
+
+                if let error = error {
+                    self?.productsErrorMessage = "商品一覧の取得に失敗しました: \(error.localizedDescription)"
+                    return
+                }
+
+                guard let data = data else {
+                    self?.productsErrorMessage = "商品一覧の取得に失敗しました"
+                    return
+                }
+
+                do {
+                    let payload = try JSONDecoder().decode(ProductsResponse.self, from: data)
+                    self?.products = payload.products
+                    if payload.products.isEmpty {
+                        self?.productsErrorMessage = "商品が登録されていません"
+                    }
+                } catch {
+                    if let errorResponse = String(data: data, encoding: .utf8) {
+                        self?.productsErrorMessage = "商品一覧の解析に失敗しました: \(errorResponse)"
+                    } else {
+                        self?.productsErrorMessage = "商品一覧の解析に失敗しました"
+                    }
+                }
+            }
+        }.resume()
+    }
+
+    func createCheckoutSession() {
+        guard let product = selectedProduct else {
+            showError("商品を選択してください")
+            return
+        }
+
+        guard !backendURL.isEmpty else {
+            showError("サーバーURLを入力してください")
+            return
+        }
+
+        guard let serverURL = URL(string: backendURL) else {
+            showError("無効なURLです")
+            return
+        }
+
+        isLoading = true
+        showResult = false
+
+        let endpoint = serverURL.appendingPathComponent("create-checkout-session")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "price_id": product.id,
+            "quantity": 1,
+            "success_url": "payjpcheckoutexample://checkout/success",
+            "cancel_url": "payjpcheckoutexample://checkout/cancel"
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, _, error in
+            DispatchQueue.main.async {
+                self?.handleCheckoutResponse(data: data, error: error)
+            }
+        }.resume()
+    }
+
+    private func handleCheckoutResponse(data: Data?, error: Error?) {
+        isLoading = false
+
+        if let error = error {
+            showError("通信エラー: \(error.localizedDescription)")
+            return
+        }
+
+        guard let data = data else {
+            showError("データが取得できませんでした")
+            return
+        }
+
+        do {
+            let session = try JSONDecoder().decode(CheckoutSessionResponse.self, from: data)
+            if let url = URL(string: session.url) {
+                checkoutURL = url
+            } else {
+                showError("無効なチェックアウトURLです")
+            }
+        } catch {
+            if let errorResponse = String(data: data, encoding: .utf8) {
+                showError("エラー: \(errorResponse)")
+            } else {
+                showError("レスポンスの解析に失敗しました")
+            }
+        }
+    }
+
+    func handleRedirectURL(_ url: URL) {
+        checkoutURL = nil
+
+        if url.absoluteString.contains("success") {
+            resultMessage = "決済が完了しました！"
+            isError = false
+        } else if url.absoluteString.contains("cancel") {
+            resultMessage = "決済がキャンセルされました"
+            isError = true
+        } else {
+            resultMessage = "不明なリダイレクト: \(url.absoluteString)"
+            isError = true
+        }
+        showResult = true
+    }
+
+    private func showError(_ message: String) {
+        resultMessage = message
+        isError = true
+        showResult = true
+    }
+}
+
+// MARK: - View
+
+struct ContentView: View {
+    @StateObject var viewModel = CheckoutViewModel()
+    @State var showSafari = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("1. サンプルサーバーURL")) {
+                    TextField("https://your-server.com", text: $viewModel.backendURL)
+                        .keyboardType(.URL)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+
+                    Button(action: {
+                        viewModel.fetchProducts()
+                    }) {
+                        HStack {
+                            if viewModel.isLoadingProducts {
+                                ProgressView()
+                                    .padding(.trailing, 8)
+                            }
+                            Text("商品一覧を取得")
+                        }
+                    }
+                    .disabled(viewModel.isLoadingProducts || viewModel.backendURL.isEmpty)
+                }
+
+                Section(header: Text("2. 商品を選択")) {
+                    if !viewModel.productsErrorMessage.isEmpty {
+                        Text(viewModel.productsErrorMessage)
+                            .font(.footnote)
+                            .foregroundColor(.red)
+                    } else if viewModel.products.isEmpty {
+                        Text("商品一覧が空です。")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    } else {
+                        ForEach(viewModel.products) { product in
+                            HStack {
+                                Image(systemName: viewModel.selectedProduct?.id == product.id
+                                        ? "largecircle.fill.circle"
+                                        : "circle")
+                                    .foregroundColor(.blue)
+
+                                Text(product.name)
+                                Spacer()
+                                Text("¥\(product.amount)")
+                                    .foregroundColor(.secondary)
+                            }
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                viewModel.selectedProduct = product
+                            }
+                        }
+                    }
+                }
+
+                Section(header: Text("3. 決済を開始")) {
+                    Button(action: {
+                        viewModel.createCheckoutSession()
+                    }) {
+                        HStack {
+                            Spacer()
+                            if viewModel.isLoading {
+                                ProgressView()
+                                    .padding(.trailing, 8)
+                            }
+                            Text("Checkout V2 で支払う")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                    }
+                    .disabled(viewModel.isLoading || viewModel.selectedProduct == nil || viewModel.backendURL.isEmpty)
+                }
+
+                if viewModel.showResult {
+                    Section(header: Text("結果")) {
+                        HStack {
+                            Image(systemName: viewModel.isError ? "xmark.circle.fill" : "checkmark.circle.fill")
+                                .foregroundColor(viewModel.isError ? .red : .green)
+                            Text(viewModel.resultMessage)
+                                .font(.subheadline)
+                        }
+                    }
+                }
+
+            }
+            .navigationTitle("Checkout V2 サンプル")
+            .onChange(of: viewModel.checkoutURL) { _, newURL in
+                showSafari = (newURL != nil)
+            }
+            .sheet(isPresented: $showSafari) {
+                if let url = viewModel.checkoutURL {
+                    SafariView(url: url)
+                        .ignoresSafeArea()
+                }
+            }
+            .onAppear {
+                viewModel.fetchProductsIfNeeded()
+            }
+        }
+    }
+}
+
+// MARK: - SFSafariViewController Wrapper
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let config = SFSafariViewController.Configuration()
+        config.entersReaderIfAvailable = false
+        let safariVC = SFSafariViewController(url: url, configuration: config)
+        return safariVC
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}
+
+#Preview {
+    ContentView()
+}

--- a/example-checkout-v2/ios/PayJPCheckoutExample/Info.plist
+++ b/example-checkout-v2/ios/PayJPCheckoutExample/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>payjpcheckoutexample</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>payjpcheckoutexample</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/example-checkout-v2/ios/PayJPCheckoutExample/PayJPCheckoutExampleApp.swift
+++ b/example-checkout-v2/ios/PayJPCheckoutExample/PayJPCheckoutExampleApp.swift
@@ -1,0 +1,31 @@
+//
+//  PayJPCheckoutExampleApp.swift
+//  PayJPCheckoutExample
+//
+//  2026/01/19.
+//
+
+import SwiftUI
+
+@main
+struct PayJPCheckoutExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .onOpenURL { url in
+                    // URL Scheme処理
+                    // payjpcheckoutexample://checkout/success または
+                    // payjpcheckoutexample://checkout/cancel
+                    NotificationCenter.default.post(
+                        name: .checkoutRedirect,
+                        object: nil,
+                        userInfo: ["url": url]
+                    )
+                }
+        }
+    }
+}
+
+extension Notification.Name {
+    static let checkoutRedirect = Notification.Name("checkoutRedirect")
+}

--- a/example-checkout-v2/ios/PayJPCheckoutExampleTests/CheckoutE2ETests.swift
+++ b/example-checkout-v2/ios/PayJPCheckoutExampleTests/CheckoutE2ETests.swift
@@ -1,0 +1,153 @@
+//
+//  CheckoutE2ETests.swift
+//  PayJPCheckoutExampleTests
+//
+//  2026/01/20.
+//
+
+import XCTest
+import Combine
+@testable import PayJPCheckoutExample
+
+final class CheckoutE2ETests: XCTestCase {
+    var viewModel: CheckoutViewModel!
+    var cancellables: Set<AnyCancellable>!
+
+    // テスト用サーバーURL（環境変数または直接指定）
+    let testServerURL = ProcessInfo.processInfo.environment["TEST_SERVER_URL"] ?? "http://localhost:3000"
+
+    override func setUp() {
+        super.setUp()
+        viewModel = CheckoutViewModel()
+        cancellables = []
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        cancellables = nil
+        super.tearDown()
+    }
+
+    // MARK: - Server Health Check
+
+    func testServerHealthCheck() async throws {
+        let url = URL(string: testServerURL)!
+        let (data, response) = try await URLSession.shared.data(from: url)
+
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(httpResponse.statusCode, 200)
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["status"] as? String, "ok")
+    }
+
+    // MARK: - Checkout Session Creation Tests
+
+    func testCreateCheckoutSessionAPICall() async throws {
+        let endpoint = URL(string: "\(testServerURL)/create-checkout-session")!
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "price_id": "price_test_123",
+            "quantity": 1,
+            "success_url": "payjpcheckoutexample://checkout/success",
+            "cancel_url": "payjpcheckoutexample://checkout/cancel"
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+
+        // サーバーが正常に応答することを確認
+        // - 200: 成功（有効なprice_idの場合）
+        // - 400/404: PAY.JP APIエラー（無効なprice_idの場合）
+        // レスポンスがJSONであることを確認
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: data),
+                         "Response should be valid JSON. Status: \(httpResponse.statusCode)")
+
+        // ステータスコードをログ出力（デバッグ用）
+        print("API Response Status: \(httpResponse.statusCode)")
+        if let responseString = String(data: data, encoding: .utf8) {
+            print("API Response Body: \(responseString)")
+        }
+    }
+
+    func testCreateCheckoutSessionMissingParams() async throws {
+        let endpoint = URL(string: "\(testServerURL)/create-checkout-session")!
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        // 必須パラメータを欠いたリクエスト
+        let body: [String: Any] = [
+            "price_id": "price_test_123"
+            // quantity, success_url, cancel_url が欠けている
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+
+        XCTAssertEqual(httpResponse.statusCode, 400)
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNotNil(json["error"])
+    }
+
+    // MARK: - Integration Test with ViewModel
+
+    func testViewModelCreateCheckoutSessionIntegration() {
+        let expectation = XCTestExpectation(description: "Checkout session creation")
+
+        viewModel.backendURL = testServerURL
+        viewModel.selectedProduct = SampleProduct(id: "price_test_123", name: "テスト商品", amount: 100)
+
+        // checkoutURL または showResult の変更を監視
+        viewModel.$checkoutURL
+            .dropFirst()
+            .sink { url in
+                if url != nil {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.$showResult
+            .dropFirst()
+            .sink { showResult in
+                if showResult {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.createCheckoutSession()
+
+        wait(for: [expectation], timeout: 10.0)
+
+        // サーバーからの応答があったことを確認
+        // （成功またはエラーのどちらか）
+        XCTAssertTrue(viewModel.checkoutURL != nil || viewModel.showResult)
+    }
+
+    // MARK: - Response Parsing Tests
+
+    func testCheckoutSessionResponseParsing() throws {
+        let jsonString = """
+        {
+            "id": "cs_test_123",
+            "url": "https://checkout.pay.jp/test",
+            "status": "open"
+        }
+        """
+        let data = jsonString.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(CheckoutSessionResponse.self, from: data)
+
+        XCTAssertEqual(response.id, "cs_test_123")
+        XCTAssertEqual(response.url, "https://checkout.pay.jp/test")
+        XCTAssertEqual(response.status, "open")
+    }
+}

--- a/example-checkout-v2/ios/PayJPCheckoutExampleTests/CheckoutViewModelTests.swift
+++ b/example-checkout-v2/ios/PayJPCheckoutExampleTests/CheckoutViewModelTests.swift
@@ -1,0 +1,124 @@
+//
+//  CheckoutViewModelTests.swift
+//  PayJPCheckoutExampleTests
+//
+//  2026/01/20.
+//
+
+import XCTest
+import Combine
+@testable import PayJPCheckoutExample
+
+final class CheckoutViewModelTests: XCTestCase {
+    var viewModel: CheckoutViewModel!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = CheckoutViewModel()
+        cancellables = []
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        cancellables = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial State Tests
+
+    func testInitialState() {
+        XCTAssertEqual(viewModel.backendURL, "http://localhost:3000")
+        XCTAssertNil(viewModel.selectedProduct)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertNil(viewModel.checkoutURL)
+        XCTAssertEqual(viewModel.resultMessage, "")
+        XCTAssertFalse(viewModel.showResult)
+        XCTAssertFalse(viewModel.isError)
+        XCTAssertTrue(viewModel.products.isEmpty)
+    }
+
+    // MARK: - Validation Tests
+
+    func testCreateCheckoutSessionWithoutProduct() {
+        viewModel.backendURL = "https://example.com"
+        viewModel.selectedProduct = nil
+
+        viewModel.createCheckoutSession()
+
+        XCTAssertTrue(viewModel.showResult)
+        XCTAssertTrue(viewModel.isError)
+        XCTAssertEqual(viewModel.resultMessage, "商品を選択してください")
+    }
+
+    func testCreateCheckoutSessionWithoutBackendURL() {
+        viewModel.backendURL = ""
+        viewModel.selectedProduct = SampleProduct(id: "price_test_123", name: "テスト商品", amount: 100)
+
+        viewModel.createCheckoutSession()
+
+        XCTAssertTrue(viewModel.showResult)
+        XCTAssertTrue(viewModel.isError)
+        XCTAssertEqual(viewModel.resultMessage, "サーバーURLを入力してください")
+    }
+
+    func testCreateCheckoutSessionStartsLoading() {
+        // Valid URL format to test that loading state is set
+        viewModel.backendURL = "http://localhost:9999"
+        viewModel.selectedProduct = SampleProduct(id: "price_test_123", name: "テスト商品", amount: 100)
+
+        viewModel.createCheckoutSession()
+
+        // When a valid URL is provided, loading should start
+        // (Note: This test may complete before the async operation finishes)
+        // The key validation is that it doesn't show an immediate error
+        XCTAssertFalse(viewModel.resultMessage == "無効なURLです")
+    }
+
+    // MARK: - URL Redirect Handling Tests
+
+    func testHandleSuccessRedirect() {
+        let successURL = URL(string: "payjpcheckoutexample://checkout/success")!
+
+        viewModel.handleRedirectURL(successURL)
+
+        XCTAssertTrue(viewModel.showResult)
+        XCTAssertFalse(viewModel.isError)
+        XCTAssertTrue(viewModel.resultMessage.contains("決済が完了しました"))
+        XCTAssertNil(viewModel.checkoutURL)
+    }
+
+    func testHandleCancelRedirect() {
+        let cancelURL = URL(string: "payjpcheckoutexample://checkout/cancel")!
+
+        viewModel.handleRedirectURL(cancelURL)
+
+        XCTAssertTrue(viewModel.showResult)
+        XCTAssertTrue(viewModel.isError)
+        XCTAssertEqual(viewModel.resultMessage, "決済がキャンセルされました")
+        XCTAssertNil(viewModel.checkoutURL)
+    }
+
+    func testHandleUnknownRedirect() {
+        let unknownURL = URL(string: "payjpcheckoutexample://checkout/unknown")!
+
+        viewModel.handleRedirectURL(unknownURL)
+
+        XCTAssertTrue(viewModel.showResult)
+        XCTAssertTrue(viewModel.isError)
+        XCTAssertTrue(viewModel.resultMessage.contains("不明なリダイレクト"))
+        XCTAssertNil(viewModel.checkoutURL)
+    }
+
+    // MARK: - Product Selection Tests
+
+    func testSelectProduct() {
+        let product = SampleProduct(id: "price_test_123", name: "テスト商品", amount: 100)
+
+        viewModel.selectedProduct = product
+
+        XCTAssertEqual(viewModel.selectedProduct?.id, product.id)
+        XCTAssertEqual(viewModel.selectedProduct?.name, product.name)
+        XCTAssertEqual(viewModel.selectedProduct?.amount, product.amount)
+    }
+}

--- a/example-checkout-v2/server/.env.example
+++ b/example-checkout-v2/server/.env.example
@@ -1,0 +1,17 @@
+# PAY.JP API キー
+# テスト環境: sk_test_xxxxx
+# 本番環境: sk_live_xxxxx
+PAYJP_SECRET_KEY=sk_test_xxxxx
+
+# Webhook シークレット（任意）
+# PAY.JP ダッシュボードで設定したトークン
+PAYJP_WEBHOOK_SECRET=whook_xxxxx
+
+# サーバーポート
+PORT=3000
+
+# サンプル商品（単一）
+PAYJP_SAMPLE_PRICE_ID=price_xxx
+PAYJP_SAMPLE_PRODUCT_NAME=テスト商品
+# 省略時は100円
+PAYJP_SAMPLE_PRODUCT_AMOUNT=100

--- a/example-checkout-v2/server/README.md
+++ b/example-checkout-v2/server/README.md
@@ -1,0 +1,104 @@
+# PAY.JP Checkout V2 サンプルサーバー
+
+PAY.JP Checkout V2 を使用した決済のサンプルサーバーです。
+
+## 前提条件
+
+- Node.js 18 以上
+- PAY.JP アカウント（テスト用 API キー）
+- PAY.JP ダッシュボードで Price オブジェクトを作成済み
+
+## セットアップ
+
+### 1. 依存関係をインストール
+
+```bash
+cd server
+npm install
+```
+
+### 2. 環境変数を設定
+
+```bash
+cp .env.example .env
+```
+
+`.env` ファイルを編集して PAY.JP の秘密鍵を設定します：
+
+```
+PAYJP_SECRET_KEY=sk_test_xxxxx
+```
+
+### 3. Price オブジェクトを作成
+
+PAY.JP ダッシュボードまたは API で Price オブジェクトを作成します。
+作成した Price ID（`price_xxx`）を `.env` の `PAYJP_SAMPLE_PRICE_ID` に設定してください。
+商品名と金額はサンプル用に任意で設定できます。
+
+### 4. サーバーを起動
+
+```bash
+npm start
+```
+
+サーバーが `http://localhost:3000` で起動します。
+
+### 5. Webhook をローカルに転送（開発時）
+
+PAY.JP CLI を使用して Webhook をローカルサーバーに転送します：
+
+```bash
+payjp-cli listen --forward-to http://localhost:3000/webhook
+```
+
+## エンドポイント
+
+### GET /products
+
+サンプル商品一覧を返します。
+
+**レスポンス:**
+```json
+{
+  "products": [
+    { "id": "price_xxx", "name": "テスト商品A", "amount": 100 }
+  ]
+}
+```
+
+### POST /create-checkout-session
+
+Checkout Session を作成します。
+
+**リクエスト:**
+```json
+{
+  "price_id": "price_xxx",
+  "quantity": 1,
+  "success_url": "payjpcheckoutexample://checkout/success",
+  "cancel_url": "payjpcheckoutexample://checkout/cancel"
+}
+```
+
+**レスポンス:**
+```json
+{
+  "id": "cs_xxx",
+  "url": "https://checkout.pay.jp/...",
+  "status": "open"
+}
+```
+
+### POST /webhook
+
+PAY.JP からの Webhook を受信します。
+
+**処理するイベント:**
+- `checkout.session.completed` - 決済完了
+- `checkout.session.expired` - セッション期限切れ
+
+## 参考リンク
+
+- [PAY.JP Checkout V2 ガイド](https://docs.pay.jp/v2/guide/payments/checkout)
+- [PAY.JP API リファレンス](https://docs.pay.jp/v2/api)
+- [PAY.JP CLI](https://docs.pay.jp/v2/guide/developers/payjp-cli)

--- a/example-checkout-v2/server/index.js
+++ b/example-checkout-v2/server/index.js
@@ -1,0 +1,151 @@
+require('dotenv').config();
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+
+app.use('/webhook', express.raw({ type: 'application/json' }));
+
+app.use((req, res, next) => {
+  if (req.path === '/webhook') {
+    return next();
+  }
+  express.json()(req, res, next);
+});
+
+const PAYJP_SECRET_KEY = process.env.PAYJP_SECRET_KEY;
+const PAYJP_API_BASE = 'https://api.pay.jp/v2';
+const SAMPLE_PRODUCTS = buildSampleProducts();
+
+function buildSampleProducts() {
+  const id = process.env.PAYJP_SAMPLE_PRICE_ID;
+  if (!id) {
+    return [];
+  }
+
+  const name = process.env.PAYJP_SAMPLE_PRODUCT_NAME || 'テスト商品';
+  const amountRaw = process.env.PAYJP_SAMPLE_PRODUCT_AMOUNT;
+  const amount = amountRaw && amountRaw.trim() !== '' && Number.isFinite(Number(amountRaw))
+    ? Number(amountRaw)
+    : 100;
+
+  return [
+    {
+      id: String(id),
+      name: String(name),
+      amount: amount
+    }
+  ];
+}
+
+// ヘルスチェック
+app.get('/', (_, res) => {
+  res.json({ status: 'ok', message: 'PAY.JP Checkout V2 Sample Server' });
+});
+
+// サンプル商品一覧
+app.get('/products', (_, res) => {
+  res.json({ products: SAMPLE_PRODUCTS });
+});
+
+// Checkout Session 作成エンドポイント
+app.post('/create-checkout-session', async (req, res) => {
+  try {
+    const { price_id, quantity, success_url, cancel_url } = req.body ?? {};
+
+    if (!PAYJP_SECRET_KEY) {
+      return res.status(500).json({ error: 'PAYJP_SECRET_KEY が設定されていません' });
+    }
+
+    if (!price_id || !quantity || !success_url || !cancel_url) {
+      return res.status(400).json({ error: '必須パラメータが不足しています' });
+    }
+
+    const response = await fetch(`${PAYJP_API_BASE}/checkout/sessions`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${Buffer.from(PAYJP_SECRET_KEY + ':').toString('base64')}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        line_items: [
+          {
+            price_id: price_id,
+            quantity: quantity
+          }
+        ],
+        mode: 'payment',
+        payment_method_types: ['card', 'paypay', 'apple_pay'],
+        success_url: success_url,
+        cancel_url: cancel_url
+      })
+    });
+
+    const session = await response.json();
+
+    if (!response.ok) {
+      console.error('PAY.JP API Error:', session);
+      return res.status(response.status).json(session);
+    }
+
+    console.log('Checkout session created:', session.id);
+    console.log('Checkout URL:', session.url);
+
+    res.json({
+      id: session.id,
+      url: session.url,
+      status: session.status
+    });
+  } catch (error) {
+    console.error('Checkout session creation failed:', error);
+    res.status(500).json({ error: 'サーバーエラーが発生しました' });
+  }
+});
+
+// Webhook エンドポイント
+app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+  const webhookToken = req.headers['x-payjp-webhook-token'];
+  const expectedToken = process.env.PAYJP_WEBHOOK_SECRET;
+
+  if (expectedToken && webhookToken !== expectedToken) {
+    console.error('Invalid webhook token');
+    return res.status(401).json({ error: 'Invalid webhook token' });
+  }
+
+  let event;
+  try {
+    event = JSON.parse(req.body.toString('utf8'));
+  } catch (err) {
+    console.error('Webhook parsing failed:', err);
+    return res.status(400).json({ error: 'Invalid JSON' });
+  }
+
+  console.log('Webhook received:', event.type);
+
+  switch (event.type) {
+    case 'checkout.session.completed':
+      console.log('決済完了:', event.data);
+      // ここで商品発送などの処理を実行
+      // 例: await fulfillOrder(event.data);
+      break;
+
+    case 'checkout.session.expired':
+      console.log('セッション期限切れ:', event.data);
+      break;
+
+    default:
+      console.log('未処理のイベント:', event.type);
+  }
+
+  res.json({ received: true });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+  console.log('');
+  console.log('エンドポイント:');
+  console.log(`  POST http://localhost:${PORT}/create-checkout-session`);
+  console.log(`  POST http://localhost:${PORT}/webhook`);
+});

--- a/example-checkout-v2/server/package-lock.json
+++ b/example-checkout-v2/server/package-lock.json
@@ -1,0 +1,862 @@
+{
+  "name": "payjp-checkout-v2-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "payjp-checkout-v2-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "dotenv": "^16.5.0",
+        "express": "^5.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/example-checkout-v2/server/package.json
+++ b/example-checkout-v2/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "payjp-checkout-v2-server",
+  "version": "1.0.0",
+  "description": "PAY.JP Checkout V2 サンプルサーバー",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.5.0"
+  }
+}


### PR DESCRIPTION
PAY.JP Checkout V2 の iOS サンプルアプリケーションを追加しました。

| Home | PayPay | ApplePay |
|--------|--------|--------|
| <img width="700" alt="image" src="https://github.com/user-attachments/assets/c3bc3860-d239-44b3-864b-bda697b0abe0" /> | <img width="590" height="1278" alt="Screenshot 2026-03-01 at 15 09 00" src="https://github.com/user-attachments/assets/d0b2caac-bf74-4a53-95c4-b65189851920" /> | <img width="590" height="1278" alt="image" src="https://github.com/user-attachments/assets/58941cb2-eedd-47d0-bd68-661a5d03079b" /> | 

##  主な変更点:

1. 新規ディレクトリ
- example-checkout-v2/ 
  - ios/ - iOS アプリコード
  - server/ - Node.js サンプルサーバー
2. 機能実装
- 商品選択 → Checkout セッション作成 → Web 決済 → アプリ復帰 の一連のフロー
- カード決済と PayPay 決済に対応（payment_method_types に card, paypay を設定）
- Webhook 受信エンドポイント（checkout.session.completed などをログ出力）

##   動作確認

```
# サーバー起動
cd example-checkout-v2/server
npm install
npm start

# 別ターミナルで Webhook 転送（任意）
payjp-cli listen --forward-to http://localhost:3000/webhook
```

- iOS アプリbackendURLで http://localhost:3000 を入力
  - 実機でテストする際は、PC のローカル IP アドレスを指定する 
- 商品を取得して選択
- 「Checkout V2 で支払う」をタップ
- カード決済でテスト（シミュレーターの場合）
- サーバーログで checkout.session.completed イベントを確認

##  テスト実行
- 単体テスト：CheckoutViewModelTests.swift
- E2E テスト：CheckoutE2ETests.swift

## TODO
- PayPay決済を実機でのみ動作確認できました
  - シミュレーターでは PayPay アプリが利用できないため
  - SafariView内のリダイレクトのみで決済する方法がないか調べます
- CIにexample-checkout-v2 のテストは含まれていません