### PR TITLE
Fix keyboard scrolling in CardFormViewController

### DIFF
--- a/Sources/Views/CardFormViewController.swift
+++ b/Sources/Views/CardFormViewController.swift
@@ -112,6 +112,8 @@ public class CardFormViewController: UIViewController {
     // MARK: Lifecycle
 
     public override func viewDidLoad() {
+        super.viewDidLoad()
+
         presenter = CardFormScreenPresenter(delegate: self)
 
         setupCardFormView()
@@ -179,12 +181,15 @@ public class CardFormViewController: UIViewController {
         submitButton.isHidden = false
     }
 
-    @objc private func keyboardDidChangeFrame(notification: Notification) {
-        let keyboardRect = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect ?? .zero
-        var keyboardY = scrollView.bounds.height - keyboardRect.origin.y
-        if keyboardY < 0 {
-            keyboardY = 0
+    @objc private func keyboardWillChangeFrame(notification: Notification) {
+        guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
+            return
         }
+
+        let keyboardFrameInView = view.convert(keyboardFrame, from: nil)
+
+        let viewBottom = view.bounds.height
+        let keyboardY = max(0, viewBottom - keyboardFrameInView.origin.y)
 
         var contentInset = scrollView.contentInset
         contentInset.bottom = keyboardY
@@ -196,15 +201,10 @@ public class CardFormViewController: UIViewController {
         scrollView.scrollIndicatorInsets = scrollIndicatorInsets
         scrollView.showsVerticalScrollIndicator = true
 
-        // displayStyledのレイアウトで横ScrollViewを使用している影響で
-        // 縦スクロールが効かないため、手動でスクロールさせるようにしている
-        // 縦スクロールが発生する画面サイズ かつ displayStyled のときのみスクロールさせる
-        let diff = scrollView.contentSize.height -
-            scrollView.bounds.size.height +
-            scrollView.contentInset.bottom
-        if keyboardY > 0 && diff > 0 && cardFormViewType == .displayStyled {
-            let offset = CGPoint(x: 0, y: diff)
-            scrollView.setContentOffset(offset, animated: true)
+        // displayStyled以外はアクティブなテキストフィールドに自動スクロール
+        if keyboardY > 0 && cardFormViewType != .displayStyled,
+           let activeField = findFirstResponder(in: scrollView) {
+            scrollToVisibleTextField(activeField, keyboardHeight: keyboardY)
         }
     }
 
@@ -212,6 +212,32 @@ public class CardFormViewController: UIViewController {
         if let value = notification.userInfo?[PAYNotificationKey.newTokenOperationStatus] as? Int,
            let newStatus = TokenOperationStatus.init(rawValue: value) {
             self.presenter?.tokenOperationStatusDidUpdate(status: newStatus)
+        }
+    }
+
+    private func findFirstResponder(in view: UIView) -> UIView? {
+        if view.isFirstResponder {
+            return view
+        }
+        for subview in view.subviews {
+            if let firstResponder = findFirstResponder(in: subview) {
+                return firstResponder
+            }
+        }
+        return nil
+    }
+
+    private func scrollToVisibleTextField(_ textField: UIView, keyboardHeight: CGFloat) {
+        let textFieldFrame = scrollView.convert(textField.bounds, from: textField)
+        let visibleHeight = scrollView.bounds.height - keyboardHeight
+
+        let padding: CGFloat = 20
+        let targetY = textFieldFrame.origin.y - padding
+
+        let maxY = textFieldFrame.maxY + padding
+        if maxY > scrollView.contentOffset.y + visibleHeight {
+            let newOffsetY = max(0, min(targetY, scrollView.contentSize.height - visibleHeight))
+            scrollView.setContentOffset(CGPoint(x: 0, y: newOffsetY), animated: true)
         }
     }
 
@@ -227,8 +253,8 @@ public class CardFormViewController: UIViewController {
                                                name: UIResponder.keyboardWillHideNotification,
                                                object: nil)
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardDidChangeFrame),
-                                               name: UIResponder.keyboardDidChangeFrameNotification,
+                                               selector: #selector(keyboardWillChangeFrame),
+                                               name: UIResponder.keyboardWillChangeFrameNotification,
                                                object: nil)
     }
 

--- a/Sources/Views/CardFormViewController.swift
+++ b/Sources/Views/CardFormViewController.swift
@@ -202,9 +202,13 @@ public class CardFormViewController: UIViewController {
         scrollView.scrollIndicatorInsets = scrollIndicatorInsets
         scrollView.showsVerticalScrollIndicator = true
 
-        // displayStyled以外はアクティブなテキストフィールドに自動スクロール
-        if keyboardY > 0 && cardFormViewType != .displayStyled,
-           let activeField = findFirstResponder(in: scrollView) {
+        // アクティブなテキストフィールドに自動スクロール
+        guard keyboardY > 0, let activeField = findFirstResponder(in: scrollView) else { return }
+
+        // displayStyledは内部に横スクロールを持つため、別処理
+        if cardFormViewType == .displayStyled {
+            scrollToVisibleForDisplayStyled(activeField: activeField, keyboardHeight: keyboardY)
+        } else {
             scrollToVisibleTextField(activeField, keyboardHeight: keyboardY)
         }
     }
@@ -233,13 +237,36 @@ public class CardFormViewController: UIViewController {
         let visibleHeight = scrollView.bounds.height - keyboardHeight
 
         let padding: CGFloat = 20
-        let targetY = textFieldFrame.origin.y - padding
-
         let maxY = textFieldFrame.maxY + padding
-        if maxY > scrollView.contentOffset.y + visibleHeight {
-            let newOffsetY = max(0, min(targetY, scrollView.contentSize.height - visibleHeight))
-            scrollView.setContentOffset(CGPoint(x: 0, y: newOffsetY), animated: true)
-        }
+
+        // キーボードで隠れていない場合はスクロールしない
+        guard maxY > scrollView.contentOffset.y + visibleHeight else { return }
+
+        let targetY = textFieldFrame.origin.y - padding
+        let newOffsetY = max(0, min(targetY, scrollView.contentSize.height - visibleHeight))
+        scrollView.setContentOffset(CGPoint(x: 0, y: newOffsetY), animated: true)
+    }
+
+    /// displayStyled専用: 内部に横スクロールがあるため、cardFormViewを基準にスクロール
+    private func scrollToVisibleForDisplayStyled(activeField: UIView, keyboardHeight: CGFloat) {
+        let visibleHeight = scrollView.bounds.height - keyboardHeight
+        let padding: CGFloat = 20
+
+        // activeFieldの実際の位置で判定（view座標系で取得してscrollViewに変換）
+        let activeFieldFrameInView = activeField.convert(activeField.bounds, to: view)
+        let keyboardTop = view.bounds.height - keyboardHeight
+
+        // キーボードで隠れていない場合はスクロールしない
+        guard activeFieldFrameInView.maxY + padding > keyboardTop else { return }
+
+        // スクロール先はcardFormViewを基準に計算（横スクロールの影響を避ける）
+        let cardFormFrame = scrollView.convert(cardFormView.bounds, from: cardFormView)
+        let relativeY = cardFormView.convert(activeField.bounds, from: activeField).origin.y
+        let activeFieldBottomY = cardFormFrame.origin.y + relativeY + activeField.bounds.height + padding
+
+        let targetY = activeFieldBottomY - visibleHeight
+        let newOffsetY = max(0, min(targetY, scrollView.contentSize.height - visibleHeight))
+        scrollView.setContentOffset(CGPoint(x: 0, y: newOffsetY), animated: true)
     }
 
     // MARK: Private

--- a/Sources/Views/CardFormViewController.swift
+++ b/Sources/Views/CardFormViewController.swift
@@ -135,6 +135,7 @@ public class CardFormViewController: UIViewController {
         brandsView.backgroundColor = Style.Color.groupedBackground
 
         setupKeyboardNotification()
+        setupKeyboardDismiss()
         fetchAccpetedBrands()
 
         NotificationCenter.default.addObserver(self,
@@ -256,6 +257,18 @@ public class CardFormViewController: UIViewController {
                                                selector: #selector(keyboardWillChangeFrame),
                                                name: UIResponder.keyboardWillChangeFrameNotification,
                                                object: nil)
+    }
+
+    private func setupKeyboardDismiss() {
+        scrollView.keyboardDismissMode = .onDrag
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
 
     private func createToken() {

--- a/example-swift/Cartfile
+++ b/example-swift/Cartfile
@@ -1,3 +1,3 @@
 # github "payjp/payjp-ios"
-git "../" "HEAD"
+git "../" "fix/card_form_keyboard_scroll_area"
 

--- a/example-swift/Cartfile
+++ b/example-swift/Cartfile
@@ -1,3 +1,3 @@
 # github "payjp/payjp-ios"
-git "../" "fix/card_form_keyboard_scroll_area"
+git "../" "HEAD"
 


### PR DESCRIPTION
# 概要

CardFormViewControllerでキーボード表示時に入力欄が隠れる問題の修正

# 対応内容

* 画面スクロール領域の計算修正
    * 横スクロール（displayStyled）の場合は計算が違うので分けて対応
* スクロール反応のタイミングを修正（keyboardDidChangeFrameNotification → keyboardWillChangeFrameNotification）
* 枠外タップ & スクロール操作時にキーボードを非表示にするように修正

# 関連Issues

* https://github.com/payjp/payjp-react-native-plugin/issues/700

# 動作検証

displayStyled以外はlabelStyledとほぼ同じなので、動画はlabelStyledのみ添付します。
検証は領域の狭いSE2端末で行っています。

| スタイル | 修正前 | 修正後 |
| --- | --- | --- |
| labelStyled | <video src="https://github.com/user-attachments/assets/eb91cfb3-a181-496e-b00d-694194148abd" /> | <video src="https://github.com/user-attachments/assets/c6eb71d3-f85f-468e-b844-0e921fa6c065"/> |
| displayStyled | <video src="https://github.com/user-attachments/assets/d6614d4f-f204-4ff9-8801-a952f3ac03c0" /> | <video src="https://github.com/user-attachments/assets/f9c1f3d0-26a5-4405-a3b0-169b0c7f08cd" /> | 










