### PR TITLE
Fix crash in labelStyled/tableStyled CardForm when using SPM

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -44,5 +44,7 @@ jobs:
       - run: bundle exec fastlane ios test
       - run: bundle exec fastlane ios lint_podspec
       - run: bundle exec fastlane ios build_swiftpm
+      - run: bundle exec fastlane ios build_spm_swift_example
+      - run: bundle exec fastlane ios build_spm_swift_ui_example
       - run: bundle exec fastlane ios build_carthage_swift_example
       - run: bundle exec fastlane ios build_cocoapods_objc_example

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ firebase-debug.log
 docs/docsets/*.tgz
 
 Brewfile.lock.json
+
+# Claude Code
+.claude

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
-github "marmelroy/PhoneNumberKit" "4.0.0"
+github "marmelroy/PhoneNumberKit" "4.2.8"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@
 ## サンプルコード
 
 - Apple Pay: https://github.com/payjp/apple-pay-example
-- CreditCard (Swift, Carthage): https://github.com/payjp/payjp-ios/tree/master/example-swift
+- CreditCard (Swift, SPM): https://github.com/payjp/payjp-ios/tree/master/example-swift
+- CreditCard (Swift, Carthage): https://github.com/payjp/payjp-ios/tree/master/example-swift (example-swift-carthageターゲット)
 - CreditCard (Objective-C, CocoaPods): https://github.com/payjp/payjp-ios/tree/master/example-objc
 
 ## 動作環境

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@
 github "payjp/payjp-ios"
 ```
 
+<details>
+<summary>Carthageサンプルアプリのビルド</summary>
+
+example-swift-carthageターゲットをローカルでビルドする場合は、fastlaneを使用してください：
+
+```bash
+bundle exec fastlane ios build_carthage_swift_example
+```
+
+このlaneは以下を自動的に実行します：
+1. PAYJP.xcframeworkの作成（iOSデバイス＋シミュレーター用）
+2. 依存ライブラリ（PhoneNumberKit等）のCarthageビルド
+3. example-swift-carthageアプリのビルド
+
+注: Package.swiftとの競合により、`carthage bootstrap`だけではビルドできません。fastlaneを使用してください。
+
+</details>
+
 [CocoaPods](https://cocoapods.org) でもインストールすることができます。
 
 ```ruby

--- a/Sources/Resources/Views/CardFormLabelStyledView.xib
+++ b/Sources/Resources/Views/CardFormLabelStyledView.xib
@@ -372,7 +372,7 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="vFN-JY-2rt">
                                             <rect key="frame" x="0.0" y="3" width="382" height="38"/>
                                             <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ZJr-ky-ClR" userLabel="Phone Input" customClass="PresetPhoneNumberTextField" customModule="PAYJP" customModuleProvider="target">
+                                                <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ZJr-ky-ClR" userLabel="Phone Input" customClass="PresetPhoneNumberTextField" customModule="PAYJP">
                                                     <rect key="frame" x="16" y="4" width="358" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="30" id="oNP-nu-nJf"/>

--- a/Sources/Resources/Views/CardFormTableStyledView.xib
+++ b/Sources/Resources/Views/CardFormTableStyledView.xib
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardFormTableStyledView" customModule="PAYJP" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardFormTableStyledView" customModule="PAYJP">
             <connections>
                 <outlet property="BasicInputsContainerView" destination="i8u-DO-8mH" id="JmJ-Ri-DhZ"/>
                 <outlet property="EmailInputView" destination="mUa-5J-GcG" id="SOS-D4-s32"/>
@@ -287,7 +287,7 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VqP-aK-5If">
                                             <rect key="frame" x="8" y="0.0" width="320" height="32"/>
                                             <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="電話番号" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="iOc-p7-bTO" userLabel="Phone Input" customClass="PresetPhoneNumberTextField" customModule="PAYJP" customModuleProvider="target">
+                                                <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="電話番号" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="iOc-p7-bTO" userLabel="Phone Input" customClass="PresetPhoneNumberTextField" customModule="PAYJP">
                                                     <rect key="frame" x="0.0" y="4" width="312" height="24"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="24" id="OvD-nc-zqN"/>

--- a/Sources/Resources/Views/ErrorView.xib
+++ b/Sources/Resources/Views/ErrorView.xib
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ErrorView" customModule="PAYJP" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ErrorView" customModule="PAYJP">
             <connections>
                 <outlet property="errorMessageLabel" destination="IUJ-L4-Ahw" id="xOj-IZ-obD"/>
                 <outlet property="reloadButton" destination="mE9-Id-iy7" id="WhN-EH-3NE"/>

--- a/example-swift/example-swift-carthage-Info.plist
+++ b/example-swift/example-swift-carthage-Info.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>exampleswift</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -3,22 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		0721B6CF2D4FBDDB0070C36F /* ThreeDSecureExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721B6CE2D4FBDCD0070C36F /* ThreeDSecureExampleViewController.swift */; };
-		07EFF5FF2D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; };
-		07EFF6002D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		07EFF6042D5CD0B400E66DAD /* ThreeDSecureProcessHandlerExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EFF6032D5CD08900E66DAD /* ThreeDSecureProcessHandlerExampleView.swift */; };
 		07EFF6062D5CE5FD00E66DAD /* CardFormViewControllerExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EFF6052D5CE5FD00E66DAD /* CardFormViewControllerExampleView.swift */; };
-		32167E0927B1C5F100E4BCD5 /* PAYJP.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; };
-		32167E0A27B1C5F100E4BCD5 /* PAYJP.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		32167E0C27B1C62900E4BCD5 /* PAYJP.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; };
-		32167E0D27B1C62900E4BCD5 /* PAYJP.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3219F14C26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3219F14B26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift */; };
-		3286226D2C6C93A700DEA55B /* PhoneNumberKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; };
-		3286226E2C6C93A700DEA55B /* PhoneNumberKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		32B471E024C6AD180061579C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471DF24C6AD180061579C /* AppDelegate.swift */; };
 		32B471E224C6AD180061579C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471E124C6AD180061579C /* SceneDelegate.swift */; };
 		32B471E424C6AD180061579C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B471E324C6AD180061579C /* ContentView.swift */; };
@@ -30,6 +22,25 @@
 		32CB112D1FDA7E3D007AD8F5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 32CB112B1FDA7E3D007AD8F5 /* Main.storyboard */; };
 		32CB112F1FDA7E3D007AD8F5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 32CB112E1FDA7E3D007AD8F5 /* Assets.xcassets */; };
 		32CB11321FDA7E3D007AD8F5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 32CB11301FDA7E3D007AD8F5 /* LaunchScreen.storyboard */; };
+		710E2C292F71A9DC0063E80D /* PAYJP in Frameworks */ = {isa = PBXBuildFile; productRef = 710E2C282F71A9DC0063E80D /* PAYJP */; };
+		710E2C2C2F71A9FF0063E80D /* PAYJP in Frameworks */ = {isa = PBXBuildFile; productRef = 710E2C2B2F71A9FF0063E80D /* PAYJP */; };
+		710E2C2F2F71AA480063E80D /* CardFormViewWith3DSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3219F14B26B1087400D2AE00 /* CardFormViewWith3DSViewController.swift */; };
+		710E2C302F71AA480063E80D /* ExampleHostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8BDA052383BA3B00680C05 /* ExampleHostViewController.swift */; };
+		710E2C312F71AA480063E80D /* CardFormViewScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5085BC232A0FE300C64A7F /* CardFormViewScrollViewController.swift */; };
+		710E2C322F71AA480063E80D /* ThreeDSecureExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0721B6CE2D4FBDCD0070C36F /* ThreeDSecureExampleViewController.swift */; };
+		710E2C332F71AA480063E80D /* ColorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED630C1623556BF4006C061E /* ColorTheme.swift */; };
+		710E2C342F71AA480063E80D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CB11291FDA7E3D007AD8F5 /* ViewController.swift */; };
+		710E2C352F71AA480063E80D /* CardFormViewExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED50839223278BB800C64A7F /* CardFormViewExampleViewController.swift */; };
+		710E2C362F71AA480063E80D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CB11271FDA7E3D007AD8F5 /* AppDelegate.swift */; };
+		710E2C372F71AA480063E80D /* SampleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDADA265238CBE780057FDF3 /* SampleService.swift */; };
+		710E2C3B2F71AA480063E80D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 32CB11301FDA7E3D007AD8F5 /* LaunchScreen.storyboard */; };
+		710E2C3C2F71AA480063E80D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = ED5085C3232A1A2B00C64A7F /* Localizable.strings */; };
+		710E2C3D2F71AA480063E80D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 32CB112E1FDA7E3D007AD8F5 /* Assets.xcassets */; };
+		710E2C3E2F71AA480063E80D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 32CB112B1FDA7E3D007AD8F5 /* Main.storyboard */; };
+		712AA0862F71AAD200CAB14B /* PAYJP.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; };
+		712AA0872F71AAD200CAB14B /* PAYJP.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32167E0827B1C5F100E4BCD5 /* PAYJP.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		712AA0882F71AAD600CAB14B /* PhoneNumberKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; };
+		712AA0892F71AAD600CAB14B /* PhoneNumberKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3286226C2C6C93A700DEA55B /* PhoneNumberKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ED50839323278BB800C64A7F /* CardFormViewExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED50839223278BB800C64A7F /* CardFormViewExampleViewController.swift */; };
 		ED5085BD232A0FE300C64A7F /* CardFormViewScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5085BC232A0FE300C64A7F /* CardFormViewScrollViewController.swift */; };
 		ED5085C1232A1A2B00C64A7F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = ED5085C3232A1A2B00C64A7F /* Localizable.strings */; };
@@ -45,8 +56,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3286226E2C6C93A700DEA55B /* PhoneNumberKit.xcframework in Embed Frameworks */,
-				32167E0A27B1C5F100E4BCD5 /* PAYJP.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -57,8 +66,18 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				07EFF6002D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Embed Frameworks */,
-				32167E0D27B1C62900E4BCD5 /* PAYJP.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		710E2C402F71AA480063E80D /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				712AA0892F71AAD600CAB14B /* PhoneNumberKit.xcframework in Embed Frameworks */,
+				712AA0872F71AAD200CAB14B /* PAYJP.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -87,6 +106,8 @@
 		32CB112E1FDA7E3D007AD8F5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		32CB11311FDA7E3D007AD8F5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		32CB11331FDA7E3D007AD8F5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		710E2C442F71AA480063E80D /* example-swift-carthage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-swift-carthage.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		710E2C452F71AA480063E80D /* example-swift-carthage-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "example-swift-carthage-Info.plist"; path = "/Users/t.tokumitsu/Developer/project/pay/payjp-ios/example-swift/example-swift-carthage-Info.plist"; sourceTree = "<absolute>"; };
 		ED50839223278BB800C64A7F /* CardFormViewExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormViewExampleViewController.swift; sourceTree = "<group>"; };
 		ED5085BC232A0FE300C64A7F /* CardFormViewScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormViewScrollViewController.swift; sourceTree = "<group>"; };
 		ED5085C2232A1A2B00C64A7F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -101,8 +122,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				07EFF5FF2D5CCBEB00E66DAD /* PhoneNumberKit.xcframework in Frameworks */,
-				32167E0C27B1C62900E4BCD5 /* PAYJP.xcframework in Frameworks */,
+				710E2C2C2F71A9FF0063E80D /* PAYJP in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,8 +130,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3286226D2C6C93A700DEA55B /* PhoneNumberKit.xcframework in Frameworks */,
-				32167E0927B1C5F100E4BCD5 /* PAYJP.xcframework in Frameworks */,
+				710E2C292F71A9DC0063E80D /* PAYJP in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		710E2C382F71AA480063E80D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				712AA0882F71AAD600CAB14B /* PhoneNumberKit.xcframework in Frameworks */,
+				712AA0862F71AAD200CAB14B /* PAYJP.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,6 +177,7 @@
 				32CB11391FDA8507007AD8F5 /* Frameworks */,
 				32CB11251FDA7E3D007AD8F5 /* Products */,
 				32CB11261FDA7E3D007AD8F5 /* example-swift */,
+				710E2C452F71AA480063E80D /* example-swift-carthage-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -157,6 +186,7 @@
 			children = (
 				32CB11241FDA7E3D007AD8F5 /* example-swift.app */,
 				32B471DD24C6AD180061579C /* example-swift-ui.app */,
+				710E2C442F71AA480063E80D /* example-swift-carthage.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -232,13 +262,32 @@
 			productReference = 32CB11241FDA7E3D007AD8F5 /* example-swift.app */;
 			productType = "com.apple.product-type.application";
 		};
+		710E2C2D2F71AA480063E80D /* example-swift-carthage */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 710E2C412F71AA480063E80D /* Build configuration list for PBXNativeTarget "example-swift-carthage" */;
+			buildPhases = (
+				710E2C2E2F71AA480063E80D /* Sources */,
+				710E2C382F71AA480063E80D /* Frameworks */,
+				710E2C3A2F71AA480063E80D /* Resources */,
+				710E2C3F2F71AA480063E80D /* Run SwiftLint */,
+				710E2C402F71AA480063E80D /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "example-swift-carthage";
+			productName = "example-ios-swift";
+			productReference = 710E2C442F71AA480063E80D /* example-swift-carthage.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		32CB111C1FDA7E3D007AD8F5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1160;
+				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 0940;
 				TargetAttributes = {
 					32B471DC24C6AD180061579C = {
@@ -262,12 +311,16 @@
 				ja,
 			);
 			mainGroup = 32CB111B1FDA7E3D007AD8F5;
+			packageReferences = (
+				710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference "../../payjp-ios" */,
+			);
 			productRefGroup = 32CB11251FDA7E3D007AD8F5 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				32CB11231FDA7E3D007AD8F5 /* example-swift */,
 				32B471DC24C6AD180061579C /* example-swift-ui */,
+				710E2C2D2F71AA480063E80D /* example-swift-carthage */,
 			);
 		};
 /* End PBXProject section */
@@ -294,6 +347,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		710E2C3A2F71AA480063E80D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				710E2C3B2F71AA480063E80D /* LaunchScreen.storyboard in Resources */,
+				710E2C3C2F71AA480063E80D /* Localizable.strings in Resources */,
+				710E2C3D2F71AA480063E80D /* Assets.xcassets in Resources */,
+				710E2C3E2F71AA480063E80D /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -316,6 +380,24 @@
 			shellScript = "sh ./run-swiftlint.sh\n";
 		};
 		32B471F324C6AF080061579C /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh ./run-swiftlint.sh\n";
+		};
+		710E2C3F2F71AA480063E80D /* Run SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -361,6 +443,22 @@
 				ED50839323278BB800C64A7F /* CardFormViewExampleViewController.swift in Sources */,
 				32CB11281FDA7E3D007AD8F5 /* AppDelegate.swift in Sources */,
 				EDADA266238CBE780057FDF3 /* SampleService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		710E2C2E2F71AA480063E80D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				710E2C2F2F71AA480063E80D /* CardFormViewWith3DSViewController.swift in Sources */,
+				710E2C302F71AA480063E80D /* ExampleHostViewController.swift in Sources */,
+				710E2C312F71AA480063E80D /* CardFormViewScrollViewController.swift in Sources */,
+				710E2C322F71AA480063E80D /* ThreeDSecureExampleViewController.swift in Sources */,
+				710E2C332F71AA480063E80D /* ColorTheme.swift in Sources */,
+				710E2C342F71AA480063E80D /* ViewController.swift in Sources */,
+				710E2C352F71AA480063E80D /* CardFormViewExampleViewController.swift in Sources */,
+				710E2C362F71AA480063E80D /* AppDelegate.swift in Sources */,
+				710E2C372F71AA480063E80D /* SampleService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -612,6 +710,48 @@
 			};
 			name = Release;
 		};
+		710E2C422F71AA480063E80D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "example-swift-carthage-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-carthage";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		710E2C432F71AA480063E80D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "example-swift-carthage-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-carthage";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -642,7 +782,35 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		710E2C412F71AA480063E80D /* Build configuration list for PBXNativeTarget "example-swift-carthage" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				710E2C422F71AA480063E80D /* Debug */,
+				710E2C432F71AA480063E80D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference "../../payjp-ios" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../../payjp-ios";
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		710E2C282F71A9DC0063E80D /* PAYJP */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PAYJP;
+		};
+		710E2C2B2F71A9FF0063E80D /* PAYJP */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference "../../payjp-ios" */;
+			productName = PAYJP;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 32CB111C1FDA7E3D007AD8F5 /* Project object */;
 }

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-ui";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.jp.pay.example-swift-ui";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -545,7 +545,7 @@
 					"@executable_path/Frameworks",
 				);
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-ui";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.jp.pay.example-swift-ui";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -682,7 +682,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.jp.pay.example-swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -703,7 +703,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.jp.pay.example-swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -724,7 +724,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-carthage";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.jp.pay.example-swift-carthage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -745,7 +745,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.exmaple.jp.pay.example-swift-carthage";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.jp.pay.example-swift-carthage";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -107,7 +107,7 @@
 		32CB11311FDA7E3D007AD8F5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		32CB11331FDA7E3D007AD8F5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		710E2C442F71AA480063E80D /* example-swift-carthage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example-swift-carthage.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		710E2C452F71AA480063E80D /* example-swift-carthage-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "example-swift-carthage-Info.plist"; path = "/Users/t.tokumitsu/Developer/project/pay/payjp-ios/example-swift/example-swift-carthage-Info.plist"; sourceTree = "<absolute>"; };
+		710E2C452F71AA480063E80D /* example-swift-carthage-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "example-swift-carthage-Info.plist"; sourceTree = "<group>"; };
 		ED50839223278BB800C64A7F /* CardFormViewExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormViewExampleViewController.swift; sourceTree = "<group>"; };
 		ED5085BC232A0FE300C64A7F /* CardFormViewScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormViewScrollViewController.swift; sourceTree = "<group>"; };
 		ED5085C2232A1A2B00C64A7F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };

--- a/example-swift/example-swift.xcodeproj/project.pbxproj
+++ b/example-swift/example-swift.xcodeproj/project.pbxproj
@@ -312,7 +312,7 @@
 			);
 			mainGroup = 32CB111B1FDA7E3D007AD8F5;
 			packageReferences = (
-				710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference "../../payjp-ios" */,
+				71BF9BC62F7D292400A6E267 /* XCLocalSwiftPackageReference ".." */,
 			);
 			productRefGroup = 32CB11251FDA7E3D007AD8F5 /* Products */;
 			projectDirPath = "";
@@ -794,9 +794,13 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference "../../payjp-ios" */ = {
+		710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference ".." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../payjp-ios";
+			relativePath = "..";
+		};
+		71BF9BC62F7D292400A6E267 /* XCLocalSwiftPackageReference ".." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "..";
 		};
 /* End XCLocalSwiftPackageReference section */
 
@@ -807,7 +811,7 @@
 		};
 		710E2C2B2F71A9FF0063E80D /* PAYJP */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference "../../payjp-ios" */;
+			package = 710E2C2A2F71A9F20063E80D /* XCLocalSwiftPackageReference ".." */;
 			productName = PAYJP;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/example-swift/example-swift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example-swift/example-swift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:/Users/tatsuyakitagawa/src/github.com/payjp/payjp-ios/example-ios-swift/example-swift.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/example-swift/example-swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/example-swift/example-swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f3e19210a27454f8820523824a29259e585f49ecc6e779b56de0c8804e574d63",
+  "pins" : [
+    {
+      "identity" : "phonenumberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/marmelroy/PhoneNumberKit.git",
+      "state" : {
+        "revision" : "54f678c2fb115e68bb173face494954c1de9df10",
+        "version" : "4.2.8"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/example-swift/example-swift.xcodeproj/xcshareddata/xcschemes/example-swift.xcscheme
+++ b/example-swift/example-swift.xcodeproj/xcshareddata/xcschemes/example-swift.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "32CB11231FDA7E3D007AD8F5"
+               BuildableName = "example-swift.app"
+               BlueprintName = "example-swift"
+               ReferencedContainer = "container:example-swift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32CB11231FDA7E3D007AD8F5"
+            BuildableName = "example-swift.app"
+            BlueprintName = "example-swift"
+            ReferencedContainer = "container:example-swift.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "32CB11231FDA7E3D007AD8F5"
+            BuildableName = "example-swift.app"
+            BlueprintName = "example-swift"
+            ReferencedContainer = "container:example-swift.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -256,7 +256,38 @@ platform :ios do
 
   desc "Build carthage-swift example app"
   lane :build_carthage_swift_example do
-    sh('cd ../example-swift && carthage bootstrap --use-xcframeworks --platform iOS --cache-builds')
+    Dir.chdir('..') do
+      # Clean up previous build artifacts
+      build_dir = './build'
+      xcframework_path = './example-swift/Carthage/Build/PAYJP.xcframework'
+      unless build_dir.empty? || build_dir == '/' || build_dir == '.'
+        if File.exist?(build_dir)
+          FileUtils.rm_rf(build_dir)
+        end
+      end
+
+      unless xcframework_path.empty? || xcframework_path == '/' || xcframework_path == '.'
+        if File.exist?(xcframework_path)
+          FileUtils.rm_rf(xcframework_path)
+        end
+      end
+
+      # First, build dependencies (PhoneNumberKit) at root level
+      sh('scripts/carthage.sh bootstrap --use-xcframeworks --platform iOS --cache-builds')
+
+      # Create archives for iOS device and simulator
+      sh('xcodebuild archive -scheme PAYJP -configuration Release -destination "generic/platform=iOS" -archivePath "./build/PAYJP.framework-iphoneos.xcarchive" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
+      sh('xcodebuild archive -scheme PAYJP -configuration Release -destination "generic/platform=iOS Simulator" -archivePath "./build/PAYJP.framework-iphonesimulator.xcarchive" SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES')
+
+      # Create xcframework and place it in example-swift/Carthage/Build
+      sh('mkdir -p example-swift/Carthage/Build')
+      sh('xcodebuild -create-xcframework -framework "./build/PAYJP.framework-iphoneos.xcarchive/Products/Library/Frameworks/PAYJP.framework" -framework "./build/PAYJP.framework-iphonesimulator.xcarchive/Products/Library/Frameworks/PAYJP.framework" -output "./example-swift/Carthage/Build/PAYJP.xcframework"')
+
+      # Copy PhoneNumberKit.xcframework to example-swift
+      sh('cp -R Carthage/Build/PhoneNumberKit.xcframework example-swift/Carthage/Build/')
+    end
+
+    # Build example app
     project_file = 'example-swift/example-swift.xcodeproj'
     build_app(
       project: project_file,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -230,12 +230,37 @@ platform :ios do
     sh('swift build -v --sdk `xcrun --sdk iphonesimulator --show-sdk-path` -Xswiftc "-target" -Xswiftc "arm64-apple-ios17.5-simulator"')
   end
 
+  desc "Build SPM-swift example app"
+  lane :build_spm_swift_example do
+    project_file = 'example-swift/example-swift.xcodeproj'
+    build_app(
+      project: project_file,
+      scheme: 'example-swift',
+      configuration: 'Debug',
+      skip_archive: true,
+      skip_codesigning: true
+    )
+  end
+
+  desc "Build SPM-swift-ui example app"
+  lane :build_spm_swift_ui_example do
+    project_file = 'example-swift/example-swift.xcodeproj'
+    build_app(
+      project: project_file,
+      scheme: 'example-swift-ui',
+      configuration: 'Debug',
+      skip_archive: true,
+      skip_codesigning: true
+    )
+  end
+
   desc "Build carthage-swift example app"
   lane :build_carthage_swift_example do
     sh('cd ../example-swift && carthage bootstrap --use-xcframeworks --platform iOS --cache-builds')
     project_file = 'example-swift/example-swift.xcodeproj'
     build_app(
       project: project_file,
+      scheme: 'example-swift-carthage',
       configuration: 'Debug',
       skip_archive: true,
       skip_codesigning: true

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -103,6 +103,22 @@ Distribute sample app with Firebase App Distribution
 
 Build with Package.swift
 
+### ios build_spm_swift_example
+
+```sh
+[bundle exec] fastlane ios build_spm_swift_example
+```
+
+Build SPM-swift example app
+
+### ios build_spm_swift_ui_example
+
+```sh
+[bundle exec] fastlane ios build_spm_swift_ui_example
+```
+
+Build SPM-swift-ui example app
+
 ### ios build_carthage_swift_example
 
 ```sh


### PR DESCRIPTION
# 概要

SPMでPAYJPを取得した場合にCardFormViewController を .labelStyled または .tableStyled で呼び出すとクラッシュします。

報告Issues（[SPM利用時にlabelStyled/tableStyledのCardFormViewでクラッシュする](https://github.com/payjp/payjp-ios/issues/108)）の原因の項目に記載されている通り、`customModuleProvider="target"`の削除で対応しました。


# 対応内容

- XIBファイルからcustomModuleProvider="target"を削除
1. CardFormLabelStyledView.xib
    - phoneNumberTextFieldの定義から削除
2. CardFormTableStyledView.xib
    - File's Owner（CardFormTableStyledViewクラス）から削除
    - phoneNumberTextFieldの定義から削除
3. ErrorView.xib
    - File's Owner（ErrorViewクラス）から削除
- Targetの`example-swift`、`example-swift-ui`をCarthageからSPMビルドに切り替え
    - Carthageも検証できるように新しく `example-swift-carthage` を追加
        - ただSPMと競合するので、`carthage bootstrap`は使用しないで、fastlaneで生成したframeworkをcarthageに取り込む方法でビルドしてもらうように変更しています


# 関連Issues

* #108 

# 動作検証

* [28f1f81](https://github.com/payjp/payjp-ios/commit/28f1f8116c6a01368608c972fcbd61b637ae7942)の状態でビルドしていただけるとクラッシュが再現できます
* [e1dd501](https://github.com/payjp/payjp-ios/commit/e1dd501a84bd87e2212e6f9f7fcf2d1e3a92ca82)の対応でクラッシュの修正を確認いたしました
