### PR TITLE
Liquid Glass 有効時にThreeDSecureWebViewControllerのナビゲーションバーが透過される問題を修正

### DIFF
--- a/Sources/ThreeDSecure/ThreeDSecureWebViewController.swift
+++ b/Sources/ThreeDSecure/ThreeDSecureWebViewController.swift
@@ -82,7 +82,15 @@ protocol ThreeDSecureWebViewControllerDelegate: AnyObject {
     private func setupNavigationBar() {
         let navItem = UINavigationItem()
         if #available(iOS 13.0, *) {
-            navigationBar.barTintColor = UIColor.systemBackground
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = UIColor.systemBackground
+            navigationBar.standardAppearance = appearance
+            navigationBar.scrollEdgeAppearance = appearance
+            navigationBar.compactAppearance = appearance
+            if #available(iOS 15.0, *) {
+                navigationBar.compactScrollEdgeAppearance = appearance
+            }
         }
         navigationBar.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(navigationBar)


### PR DESCRIPTION
## 概要

iOS 26 で Liquid Glass が有効な場合に `ThreeDSecureWebViewController`  のナビゲーションバーが透過されてしまい、閉じるボタンやナビゲーションバーが認識しづらくなる問題を修正しました

## 関連Issues

- https://github.com/payjp/payjp-ios/issues/111

## 動作検証

| iOS 26.4 | iOS 18.0 |
|:-----:|:-----:|
| <img width="320" alt="スクリーンショット 2026-04-22 12 20 23" src="https://github.com/user-attachments/assets/0937de31-d6da-4902-8371-8c1658518e44" />  | <img width="320" alt="スクリーンショット 2026-04-22 12 06 55" src="https://github.com/user-attachments/assets/c5f428d8-56e4-468f-a9ed-edf716d2b049" /> |
