### PR TITLE
Fix clear button not working on scrolled text fields in CardFormViewController

### DIFF
--- a/Sources/Views/CardFormViewController.swift
+++ b/Sources/Views/CardFormViewController.swift
@@ -291,6 +291,7 @@ public class CardFormViewController: UIViewController {
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tapGesture.cancelsTouchesInView = false
+        tapGesture.delegate = self
         view.addGestureRecognizer(tapGesture)
     }
 
@@ -495,5 +496,21 @@ extension CardFormViewController: ThreeDSecureProcessHandlerDelegate {
         default:
             break
         }
+    }
+}
+
+// MARK: UIGestureRecognizerDelegate
+extension CardFormViewController: UIGestureRecognizerDelegate {
+
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                                  shouldReceive touch: UITouch) -> Bool {
+        var view = touch.view
+        while let v = view {
+            if v is UITextField {
+                return false
+            }
+            view = v.superview
+        }
+        return true
     }
 }


### PR DESCRIPTION
# 概要

* キーボード表示によりスクロールして表示されるテキストフィールドで、クリアボタン（×）をタップしても入力値が削除されない不具合
* #106 、修正の影響で発生

# 対応内容

* 原因
    * UITapGestureRecognizer がクリアボタンのタップより先に発火し、view.endEditing(true)でキーボードを閉じてしまうため、クリアボタンのイベントがキャンセルされる。
* 修正方針
    * UIGestureRecognizerDelegate の gestureRecognizer(_:shouldReceive:) を実装し、タッチ先が UITextField（またはそのサブビュー = クリアボタン）の場合はジェスチャーを無効にする。

# 関連Issues & PR

* https://github.com/payjp/payjp-ios/issues/110
* https://github.com/payjp/payjp-ios/pull/106

# 動作検証

| 修正前 | 修正後 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/efcdbe67-032d-4d24-afb2-f75a3689a80d" /> | <video src="https://github.com/user-attachments/assets/7870a7f9-2fef-4601-9acb-029f0e2cbd87" /> |





